### PR TITLE
feat: setup command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ dependencies {
 	implementation 'javax.xml.bind:jaxb-api'
 	implementation 'org.glassfish.jaxb:jaxb-runtime'
 
+    implementation 'org.apache.commons:commons-text:1.14.0'
 	implementation 'org.yaml:snakeyaml:2.5'
 	implementation "org.openrewrite:rewrite-gradle:${openrewriteVersion}"
 	implementation "org.openrewrite:rewrite-kotlin:${openrewriteVersion}"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.11.1
+version=0.12.0

--- a/src/main/java/com/canonical/devpackspring/IProcessUtil.java
+++ b/src/main/java/com/canonical/devpackspring/IProcessUtil.java
@@ -1,0 +1,9 @@
+package com.canonical.devpackspring;
+
+import org.springframework.cli.util.TerminalMessage;
+
+import java.io.IOException;
+
+public interface IProcessUtil {
+    int runProcess(final TerminalMessage message, boolean inheritIO, String ...args) throws IOException;
+}

--- a/src/main/java/com/canonical/devpackspring/IProcessUtil.java
+++ b/src/main/java/com/canonical/devpackspring/IProcessUtil.java
@@ -1,9 +1,27 @@
-package com.canonical.devpackspring;
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import org.springframework.cli.util.TerminalMessage;
+package com.canonical.devpackspring;
 
 import java.io.IOException;
 
+import org.springframework.cli.util.TerminalMessage;
+
 public interface IProcessUtil {
-    int runProcess(final TerminalMessage message, boolean inheritIO, String ...args) throws IOException;
+
+	int runProcess(TerminalMessage message, boolean inheritIO, String... args) throws IOException;
+
 }

--- a/src/main/java/com/canonical/devpackspring/ProcessUtil.java
+++ b/src/main/java/com/canonical/devpackspring/ProcessUtil.java
@@ -29,6 +29,14 @@ import org.springframework.cli.util.TerminalMessage;
  */
 public abstract class ProcessUtil {
 
+    public static int runProcess(final TerminalMessage message, boolean inheritIO, String ...args) throws IOException {
+        ProcessBuilder pb = new ProcessBuilder(args);
+        if (inheritIO) {
+            pb = pb.inheritIO();
+        }
+        return runProcess(message, pb);
+    }
+
 	/**
 	 * Starts the process and outputs to the provided terminal message
 	 * @param message - TerminalMessage

--- a/src/main/java/com/canonical/devpackspring/ProcessUtil.java
+++ b/src/main/java/com/canonical/devpackspring/ProcessUtil.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package com.canonical.devpackspring.build;
+package com.canonical.devpackspring;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/src/main/java/com/canonical/devpackspring/ProcessUtil.java
+++ b/src/main/java/com/canonical/devpackspring/ProcessUtil.java
@@ -29,13 +29,13 @@ import org.springframework.cli.util.TerminalMessage;
  */
 public abstract class ProcessUtil {
 
-    public static int runProcess(final TerminalMessage message, boolean inheritIO, String ...args) throws IOException {
-        ProcessBuilder pb = new ProcessBuilder(args);
-        if (inheritIO) {
-            pb = pb.inheritIO();
-        }
-        return runProcess(message, pb);
-    }
+	public static int runProcess(final TerminalMessage message, boolean inheritIO, String... args) throws IOException {
+		ProcessBuilder pb = new ProcessBuilder(args);
+		if (inheritIO) {
+			pb = pb.inheritIO();
+		}
+		return runProcess(message, pb);
+	}
 
 	/**
 	 * Starts the process and outputs to the provided terminal message

--- a/src/main/java/com/canonical/devpackspring/build/MavenRunner.java
+++ b/src/main/java/com/canonical/devpackspring/build/MavenRunner.java
@@ -22,6 +22,7 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.StringTokenizer;
 
+import com.canonical.devpackspring.ProcessUtil;
 import org.springframework.cli.util.TerminalMessage;
 
 public abstract class MavenRunner {

--- a/src/main/java/com/canonical/devpackspring/build/MavenRunner.java
+++ b/src/main/java/com/canonical/devpackspring/build/MavenRunner.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.StringTokenizer;
 
 import com.canonical.devpackspring.ProcessUtil;
+
 import org.springframework.cli.util.TerminalMessage;
 
 public abstract class MavenRunner {

--- a/src/main/java/com/canonical/devpackspring/build/gradle/GradleAdapter.java
+++ b/src/main/java/com/canonical/devpackspring/build/gradle/GradleAdapter.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import com.canonical.devpackspring.build.ProcessUtil;
+import com.canonical.devpackspring.ProcessUtil;
 import org.gradle.initialization.BuildCancellationToken;
 import org.gradle.internal.classpath.ClassPath;
 import org.gradle.internal.logging.progress.ProgressLogger;

--- a/src/main/java/com/canonical/devpackspring/setup/SetupCategory.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupCategory.java
@@ -23,7 +23,8 @@ import java.util.Map;
 public class SetupCategory {
 
 	private String name;
-    private String description;
+
+	private String description;
 
 	private boolean allowMultiSelect;
 
@@ -32,10 +33,10 @@ public class SetupCategory {
 	public SetupCategory(SetupEntryFactory factory, String name, Map<String, Object> data) {
 		this.name = name;
 
-        this.description = (String)data.get("description");
-        if (this.description == null) {
-            this.description = name;
-        }
+		this.description = (String) data.get("description");
+		if (this.description == null) {
+			this.description = name;
+		}
 
 		Object o = data.get("multiselect");
 		if (o == null) {
@@ -59,9 +60,9 @@ public class SetupCategory {
 			}
 		}
 
-        if (!allowMultiSelect) {
-            setupEntries.stream().filter( x -> x.selected() ).forEach( x -> x.setSuffix(" [installed]"));
-        }
+		if (!allowMultiSelect) {
+			setupEntries.stream().filter(x -> x.selected()).forEach(x -> x.setSuffix(" [installed]"));
+		}
 
 	}
 
@@ -69,9 +70,9 @@ public class SetupCategory {
 		return name;
 	}
 
-    public String getDescription() {
-        return description;
-    }
+	public String getDescription() {
+		return description;
+	}
 
 	public boolean isAllowMultiSelect() {
 		return allowMultiSelect;

--- a/src/main/java/com/canonical/devpackspring/setup/SetupCategory.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupCategory.java
@@ -29,7 +29,7 @@ public class SetupCategory {
 
 	private final ArrayList<SetupEntry> setupEntries;
 
-	public SetupCategory(String name, Map<String, Object> data) {
+	public SetupCategory(SetupEntryFactory factory, String name, Map<String, Object> data) {
 		this.name = name;
 
         this.description = (String)data.get("description");
@@ -46,7 +46,6 @@ public class SetupCategory {
 		}
 
 		this.setupEntries = new ArrayList<>();
-		SetupEntryFactory factory = new SetupEntryFactory();
 		var apt = (List<Map<String, Object>>) data.get("apt");
 		if (apt != null) {
 			for (Map<String, Object> item : apt) {

--- a/src/main/java/com/canonical/devpackspring/setup/SetupCategory.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupCategory.java
@@ -17,22 +17,26 @@
 package com.canonical.devpackspring.setup;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
 public class SetupCategory {
 
 	private String name;
+    private String description;
 
 	private boolean allowMultiSelect;
 
 	private final ArrayList<SetupEntry> setupEntries;
 
-	private final ArrayList<String> setupEntryNames;
-
 	public SetupCategory(String name, Map<String, Object> data) {
 		this.name = name;
+
+        this.description = (String)data.get("description");
+        if (this.description == null) {
+            this.description = name;
+        }
+
 		Object o = data.get("multiselect");
 		if (o == null) {
 			this.allowMultiSelect = true;
@@ -55,7 +59,10 @@ public class SetupCategory {
 				setupEntries.add(factory.createSnapEntry(item));
 			}
 		}
-		setupEntryNames = new ArrayList<>(Arrays.asList(new String[setupEntries.size()]));
+
+        if (!allowMultiSelect) {
+            setupEntries.stream().filter( x -> x.selected() ).forEach( x -> x.setSuffix(" [installed]"));
+        }
 
 	}
 
@@ -63,16 +70,16 @@ public class SetupCategory {
 		return name;
 	}
 
+    public String getDescription() {
+        return description;
+    }
+
 	public boolean isAllowMultiSelect() {
 		return allowMultiSelect;
 	}
 
 	public ArrayList<SetupEntry> getSetupEntries() {
 		return setupEntries;
-	}
-
-	public List<String> getResultValues() {
-		return setupEntryNames;
 	}
 
 }

--- a/src/main/java/com/canonical/devpackspring/setup/SetupCategory.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupCategory.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring.setup;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+public class SetupCategory {
+
+	private String name;
+
+	private boolean allowMultiSelect;
+
+	private final ArrayList<SetupEntry> setupEntries;
+
+	private final ArrayList<String> setupEntryNames;
+
+	public SetupCategory(String name, Map<String, Object> data) {
+		this.name = name;
+		Object o = data.get("multiselect");
+		if (o == null) {
+			this.allowMultiSelect = true;
+		}
+		else {
+			this.allowMultiSelect = Boolean.parseBoolean(o.toString());
+		}
+
+		this.setupEntries = new ArrayList<>();
+		SetupEntryFactory factory = new SetupEntryFactory();
+		var apt = (List<Map<String, Object>>) data.get("apt");
+		if (apt != null) {
+			for (Map<String, Object> item : apt) {
+				setupEntries.add(factory.createAptEntry(item));
+			}
+		}
+		var snap = (List<Map<String, Object>>) data.get("snap");
+		if (snap != null) {
+			for (Map<String, Object> item : snap) {
+				setupEntries.add(factory.createSnapEntry(item));
+			}
+		}
+		setupEntryNames = new ArrayList<>(Arrays.asList(new String[setupEntries.size()]));
+
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public boolean isAllowMultiSelect() {
+		return allowMultiSelect;
+	}
+
+	public ArrayList<SetupEntry> getSetupEntries() {
+		return setupEntries;
+	}
+
+	public List<String> getResultValues() {
+		return setupEntryNames;
+	}
+
+}

--- a/src/main/java/com/canonical/devpackspring/setup/SetupEntry.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupEntry.java
@@ -21,6 +21,8 @@ import java.util.ArrayList;
 
 import com.canonical.devpackspring.ProcessUtil;
 
+import org.apache.commons.text.StringSubstitutor;
+
 import org.springframework.cli.util.TerminalMessage;
 import org.springframework.shell.component.flow.DefaultSelectItem;
 
@@ -28,10 +30,22 @@ public abstract class SetupEntry extends DefaultSelectItem {
 
 	private ArrayList<String> extraCommands;
 
-	public SetupEntry(String name, String description, ArrayList<String> extraCommands) {
-		super(description, name, true, false);
+	private StringSubstitutor substitutor = new StringSubstitutor();
+    private String suffix;
+
+    public SetupEntry(String name, String description, ArrayList<String> extraCommands, boolean selected) {
+		super(description, name, true, selected);
 		this.extraCommands = extraCommands;
+        this.suffix = "";
 	}
+
+    public String name() {
+        return super.name() + suffix;
+    }
+
+    public void setSuffix(String suffix) {
+        this.suffix = suffix;
+    }
 
 	public abstract boolean install(TerminalMessage msg) throws IOException;
 
@@ -42,6 +56,7 @@ public abstract class SetupEntry extends DefaultSelectItem {
 			return true;
 		}
 		for (var command : extraCommands) {
+			command = substitutor.replace(command); // expand macros
 			ProcessBuilder pb = new ProcessBuilder(command.split(" "));
 			int exitCode = ProcessUtil.runProcess(msg, pb);
 			if (exitCode != 0) {

--- a/src/main/java/com/canonical/devpackspring/setup/SetupEntry.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupEntry.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring.setup;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import com.canonical.devpackspring.ProcessUtil;
+
+import org.springframework.cli.util.TerminalMessage;
+import org.springframework.shell.component.flow.DefaultSelectItem;
+
+public abstract class SetupEntry extends DefaultSelectItem {
+
+	private ArrayList<String> extraCommands;
+
+	public SetupEntry(String name, String description, ArrayList<String> extraCommands) {
+		super(description, name, true, false);
+		this.extraCommands = extraCommands;
+	}
+
+	public abstract boolean install(TerminalMessage msg) throws IOException;
+
+	public abstract boolean remove(TerminalMessage msg) throws IOException;
+
+	protected boolean executeExtraCommands(TerminalMessage msg) throws IOException {
+		if (extraCommands == null) {
+			return true;
+		}
+		for (var command : extraCommands) {
+			ProcessBuilder pb = new ProcessBuilder(command.split(" "));
+			int exitCode = ProcessUtil.runProcess(msg, pb);
+			if (exitCode != 0) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+}

--- a/src/main/java/com/canonical/devpackspring/setup/SetupEntry.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupEntry.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 import com.canonical.devpackspring.IProcessUtil;
-
 import org.apache.commons.text.StringSubstitutor;
 
 import org.springframework.cli.util.TerminalMessage;
@@ -31,21 +30,22 @@ public abstract class SetupEntry extends DefaultSelectItem {
 	private ArrayList<String> extraCommands;
 
 	private StringSubstitutor substitutor = new StringSubstitutor();
-    private String suffix;
 
-    public SetupEntry(String name, String description, ArrayList<String> extraCommands, boolean selected) {
+	private String suffix;
+
+	public SetupEntry(String name, String description, ArrayList<String> extraCommands, boolean selected) {
 		super(description, name, true, selected);
 		this.extraCommands = extraCommands;
-        this.suffix = "";
+		this.suffix = "";
 	}
 
-    public String name() {
-        return super.name() + suffix;
-    }
+	public String name() {
+		return super.name() + suffix;
+	}
 
-    public void setSuffix(String suffix) {
-        this.suffix = suffix;
-    }
+	public void setSuffix(String suffix) {
+		this.suffix = suffix;
+	}
 
 	public abstract boolean install(TerminalMessage msg) throws IOException;
 

--- a/src/main/java/com/canonical/devpackspring/setup/SetupEntry.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupEntry.java
@@ -19,7 +19,7 @@ package com.canonical.devpackspring.setup;
 import java.io.IOException;
 import java.util.ArrayList;
 
-import com.canonical.devpackspring.ProcessUtil;
+import com.canonical.devpackspring.IProcessUtil;
 
 import org.apache.commons.text.StringSubstitutor;
 
@@ -51,14 +51,13 @@ public abstract class SetupEntry extends DefaultSelectItem {
 
 	public abstract boolean remove(TerminalMessage msg) throws IOException;
 
-	protected boolean executeExtraCommands(TerminalMessage msg) throws IOException {
+	protected boolean executeExtraCommands(TerminalMessage msg, IProcessUtil ipc) throws IOException {
 		if (extraCommands == null) {
 			return true;
 		}
 		for (var command : extraCommands) {
 			command = substitutor.replace(command); // expand macros
-			ProcessBuilder pb = new ProcessBuilder(command.split(" "));
-			int exitCode = ProcessUtil.runProcess(msg, pb);
+			int exitCode = ipc.runProcess(msg, false, command.split(" "));
 			if (exitCode != 0) {
 				return false;
 			}

--- a/src/main/java/com/canonical/devpackspring/setup/SetupEntryFactory.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupEntryFactory.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring.setup;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Map;
+
+import com.canonical.devpackspring.ProcessUtil;
+
+import org.springframework.cli.util.TerminalMessage;
+
+public class SetupEntryFactory {
+
+	SetupEntry createSnapEntry(Map<String, Object> item) {
+		if (item.size() != 1) {
+			throw new IllegalArgumentException("Apt entry should be a map of size 1");
+		}
+		String name = item.keySet().iterator().next();
+		var data = (Map<String, Object>) item.get(name);
+		String description = (String) data.get("description");
+		ArrayList<String> extraCommands = (ArrayList<String>) data.get("extra-commands");
+		return new SetupEntry(name, description, extraCommands) {
+			@Override
+			public boolean install(TerminalMessage msg) throws IOException {
+				ProcessBuilder pb = new ProcessBuilder("snap", "install", name());
+				int exitCode = ProcessUtil.runProcess(msg, pb);
+				if (exitCode != 0) {
+					return false;
+				}
+				return executeExtraCommands(msg);
+			}
+
+			@Override
+			public boolean remove(TerminalMessage msg) throws IOException {
+				ProcessBuilder pb = new ProcessBuilder("snap", "remove", name());
+				return ProcessUtil.runProcess(msg, pb) == 0;
+			}
+		};
+	}
+
+	SetupEntry createAptEntry(Map<String, Object> item) {
+		if (item.size() != 1) {
+			throw new IllegalArgumentException("Apt entry should be a map of size 1");
+		}
+		String name = item.keySet().iterator().next();
+		var data = (Map<String, Object>) item.get(name);
+		String description = (String) data.get("description");
+		ArrayList<String> extraCommands = (ArrayList<String>) data.get("extra-commands");
+		return new SetupEntry(name, description, extraCommands) {
+			@Override
+			public boolean install(TerminalMessage msg) throws IOException {
+				ProcessBuilder pb = new ProcessBuilder("apt", "update");
+				int exitCode = ProcessUtil.runProcess(msg, pb);
+				if (exitCode != 0) {
+					return false;
+				}
+				pb = new ProcessBuilder("apt", "install", "-y", name());
+				exitCode = ProcessUtil.runProcess(msg, pb);
+				if (exitCode != 0) {
+					return false;
+				}
+				return executeExtraCommands(msg);
+			}
+
+			@Override
+			public boolean remove(TerminalMessage msg) throws IOException {
+				ProcessBuilder pb = new ProcessBuilder("apt", "remove", "-y", name());
+				return ProcessUtil.runProcess(msg, pb) == 0;
+			}
+		};
+	}
+
+}

--- a/src/main/java/com/canonical/devpackspring/setup/SetupEntryFactory.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupEntryFactory.java
@@ -22,6 +22,8 @@ import java.util.Map;
 
 import com.canonical.devpackspring.ProcessUtil;
 
+import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStyle;
 import org.springframework.cli.util.TerminalMessage;
 
 public class SetupEntryFactory {
@@ -30,24 +32,41 @@ public class SetupEntryFactory {
 		if (item.size() != 1) {
 			throw new IllegalArgumentException("Apt entry should be a map of size 1");
 		}
-		String name = item.keySet().iterator().next();
-		var data = (Map<String, Object>) item.get(name);
+		String itemId = item.keySet().iterator().next();
+		var data = (Map<String, Object>) item.get(itemId);
 		String description = (String) data.get("description");
 		ArrayList<String> extraCommands = (ArrayList<String>) data.get("extra-commands");
-		return new SetupEntry(name, description, extraCommands) {
+
+        var installed = isInstalled("/bin/sh", "-c", String.format("snap info %s | grep -q \"installed:\"", itemId));
+
+		return new SetupEntry(itemId, description, extraCommands, installed) {
 			@Override
 			public boolean install(TerminalMessage msg) throws IOException {
-				ProcessBuilder pb = new ProcessBuilder("snap", "install", name());
-				int exitCode = ProcessUtil.runProcess(msg, pb);
+                if (installed) {
+                    msg.print(String.format("Snap %s is already installed.", item()));
+                    return true;
+                }
+				ProcessBuilder pb = new ProcessBuilder("sudo", "snap", "install", item()).inheritIO();
+                AttributedStyle style = new AttributedStyle().foreground(AttributedStyle.RED);
+
+                int exitCode = ProcessUtil.runProcess(msg, pb);
 				if (exitCode != 0) {
+                    msg.print(new AttributedString(String.format("Failed to install snap %s.", item()), style));
 					return false;
 				}
-				return executeExtraCommands(msg);
+				boolean ret = executeExtraCommands(msg);
+                if (!ret) {
+                    msg.print(new AttributedString(String.format("Failed to install snap %s. Post-installation commands failed.", item()), style));
+                }
+                return ret;
 			}
 
 			@Override
 			public boolean remove(TerminalMessage msg) throws IOException {
-				ProcessBuilder pb = new ProcessBuilder("snap", "remove", name());
+                if (!installed) {
+                    return true;
+                }
+				ProcessBuilder pb = new ProcessBuilder("sudo", "snap", "remove", item()).inheritIO();
 				return ProcessUtil.runProcess(msg, pb) == 0;
 			}
 		};
@@ -57,32 +76,61 @@ public class SetupEntryFactory {
 		if (item.size() != 1) {
 			throw new IllegalArgumentException("Apt entry should be a map of size 1");
 		}
-		String name = item.keySet().iterator().next();
-		var data = (Map<String, Object>) item.get(name);
+		String itemId = item.keySet().iterator().next();
+		var data = (Map<String, Object>) item.get(itemId);
 		String description = (String) data.get("description");
 		ArrayList<String> extraCommands = (ArrayList<String>) data.get("extra-commands");
-		return new SetupEntry(name, description, extraCommands) {
+        var installed = isInstalled("/bin/sh", "-c",  String.format("dpkg -s %s | grep -q \"Status: install ok installed\"", itemId));
+		return new SetupEntry(itemId, description, extraCommands, installed) {
 			@Override
 			public boolean install(TerminalMessage msg) throws IOException {
-				ProcessBuilder pb = new ProcessBuilder("apt", "update");
-				int exitCode = ProcessUtil.runProcess(msg, pb);
+                if (installed) {
+                    msg.print(String.format("Package %s is already installed.", item()));
+                    return true;
+                }
+				ProcessBuilder pb = new ProcessBuilder("sudo", "apt-get", "update").inheritIO();
+
+                AttributedStyle style = new AttributedStyle().foreground(AttributedStyle.RED);
+                int exitCode = ProcessUtil.runProcess(msg, pb);
 				if (exitCode != 0) {
-					return false;
+                    msg.print(new AttributedString(String.format("Failed to install package %s.", item()), style));
+                    return false;
 				}
-				pb = new ProcessBuilder("apt", "install", "-y", name());
+				pb = new ProcessBuilder("sudo", "apt-get", "install", "-y", item()).inheritIO();
+
 				exitCode = ProcessUtil.runProcess(msg, pb);
 				if (exitCode != 0) {
+                    msg.print(new AttributedString(String.format("Failed to install package %s.", item()), style));
 					return false;
 				}
-				return executeExtraCommands(msg);
+                boolean ret = executeExtraCommands(msg);
+                if (!ret) {
+                    msg.print(new AttributedString(String.format("Failed to install package %s. Post-installation commands failed.", item()), style));
+                }
+                return ret;
 			}
 
 			@Override
 			public boolean remove(TerminalMessage msg) throws IOException {
-				ProcessBuilder pb = new ProcessBuilder("apt", "remove", "-y", name());
+                if (!installed) {
+                    return true;
+                }
+				ProcessBuilder pb = new ProcessBuilder("sudo", "apt-get", "remove", "-y", item());
 				return ProcessUtil.runProcess(msg, pb) == 0;
 			}
 		};
+	}
+
+	private boolean isInstalled(String... args) {
+		ProcessBuilder pb = new ProcessBuilder(args);
+		TerminalMessage message = TerminalMessage.noop();
+		try {
+			int exitCode = ProcessUtil.runProcess(message, pb);
+			return exitCode == 0;
+		}
+		catch (IOException e) {
+			throw new RuntimeException(e);
+		}
 	}
 
 }

--- a/src/main/java/com/canonical/devpackspring/setup/SetupEntryFactory.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupEntryFactory.java
@@ -21,18 +21,18 @@ import java.util.ArrayList;
 import java.util.Map;
 
 import com.canonical.devpackspring.IProcessUtil;
-
 import org.jline.utils.AttributedString;
 import org.jline.utils.AttributedStyle;
+
 import org.springframework.cli.util.TerminalMessage;
 
 public class SetupEntryFactory {
 
-    private IProcessUtil processUtil;
+	private IProcessUtil processUtil;
 
-    public SetupEntryFactory(IProcessUtil processUtil) {
-        this.processUtil = processUtil;
-    }
+	public SetupEntryFactory(IProcessUtil processUtil) {
+		this.processUtil = processUtil;
+	}
 
 	SetupEntry createSnapEntry(Map<String, Object> item) {
 		if (item.size() != 1) {
@@ -43,34 +43,37 @@ public class SetupEntryFactory {
 		String description = (String) data.get("description");
 		ArrayList<String> extraCommands = (ArrayList<String>) data.get("extra-commands");
 
-        var installed = isInstalled("/bin/sh", "-c", String.format("snap info %s | grep -q \"installed:\"", itemId));
+		var installed = isInstalled("/bin/sh", "-c", String.format("snap info %s | grep -q \"installed:\"", itemId));
 
 		return new SetupEntry(itemId, description, extraCommands, installed) {
 			@Override
 			public boolean install(TerminalMessage msg) throws IOException {
-                if (installed) {
-                    msg.print(String.format("Snap %s is already installed.", item()));
-                    return true;
-                }
-                AttributedStyle style = new AttributedStyle().foreground(AttributedStyle.RED);
+				if (installed) {
+					msg.print(String.format("Snap %s is already installed.", item()));
+					return true;
+				}
+				AttributedStyle style = new AttributedStyle().foreground(AttributedStyle.RED);
 
-                int exitCode = processUtil.runProcess(msg, true, "sudo", "snap", "install", item());
+				int exitCode = processUtil.runProcess(msg, true, "sudo", "snap", "install", item());
 				if (exitCode != 0) {
-                    msg.print(new AttributedString(String.format("Failed to install snap %s.", item()), style));
+					msg.print(new AttributedString(String.format("Failed to install snap %s.", item()), style));
 					return false;
 				}
 				boolean ret = executeExtraCommands(msg, processUtil);
-                if (!ret) {
-                    msg.print(new AttributedString(String.format("Failed to install snap %s. Post-installation commands failed.", item()), style));
-                }
-                return ret;
+				if (!ret) {
+					msg.print(new AttributedString(
+							String.format("Failed to install snap %s. Post-installation commands failed.", item()),
+							style));
+				}
+				msg.print(String.format("%s was successfully installed.", name()));
+				return ret;
 			}
 
 			@Override
 			public boolean remove(TerminalMessage msg) throws IOException {
-                if (!installed) {
-                    return true;
-                }
+				if (!installed) {
+					return true;
+				}
 				return processUtil.runProcess(msg, true, "sudo", "snap", "remove", item()) == 0;
 			}
 		};
@@ -84,37 +87,41 @@ public class SetupEntryFactory {
 		var data = (Map<String, Object>) item.get(itemId);
 		String description = (String) data.get("description");
 		ArrayList<String> extraCommands = (ArrayList<String>) data.get("extra-commands");
-        var installed = isInstalled("/bin/sh", "-c",  String.format("dpkg -s %s | grep -q \"Status: install ok installed\"", itemId));
+		var installed = isInstalled("/bin/sh", "-c",
+				String.format("dpkg -s %s | grep -q \"Status: install ok installed\"", itemId));
 		return new SetupEntry(itemId, description, extraCommands, installed) {
 			@Override
 			public boolean install(TerminalMessage msg) throws IOException {
-                if (installed) {
-                    msg.print(String.format("Package %s is already installed.", item()));
-                    return true;
-                }
-                AttributedStyle style = new AttributedStyle().foreground(AttributedStyle.RED);
-                int exitCode = processUtil.runProcess(msg, true, "sudo", "apt-get", "update");
+				if (installed) {
+					msg.print(String.format("Package %s is already installed.", item()));
+					return true;
+				}
+				AttributedStyle style = new AttributedStyle().foreground(AttributedStyle.RED);
+				int exitCode = processUtil.runProcess(msg, true, "sudo", "apt-get", "update");
 				if (exitCode != 0) {
-                    msg.print(new AttributedString(String.format("Failed to install package %s.", item()), style));
-                    return false;
+					msg.print(new AttributedString(String.format("Failed to install package %s.", item()), style));
+					return false;
 				}
 				exitCode = processUtil.runProcess(msg, true, "sudo", "apt-get", "install", "-y", item());
 				if (exitCode != 0) {
-                    msg.print(new AttributedString(String.format("Failed to install package %s.", item()), style));
+					msg.print(new AttributedString(String.format("Failed to install package %s.", item()), style));
 					return false;
 				}
-                boolean ret = executeExtraCommands(msg, processUtil);
-                if (!ret) {
-                    msg.print(new AttributedString(String.format("Failed to install package %s. Post-installation commands failed.", item()), style));
-                }
-                return ret;
+				boolean ret = executeExtraCommands(msg, processUtil);
+				if (!ret) {
+					msg.print(new AttributedString(
+							String.format("Failed to install package %s. Post-installation commands failed.", item()),
+							style));
+				}
+				msg.print(String.format("%s was successfully installed.", name()));
+				return ret;
 			}
 
 			@Override
 			public boolean remove(TerminalMessage msg) throws IOException {
-                if (!installed) {
-                    return true;
-                }
+				if (!installed) {
+					return true;
+				}
 				return processUtil.runProcess(msg, true, "sudo", "apt-get", "remove", "-y", item()) == 0;
 			}
 		};
@@ -126,8 +133,8 @@ public class SetupEntryFactory {
 			int exitCode = processUtil.runProcess(message, false, args);
 			return exitCode == 0;
 		}
-		catch (IOException e) {
-			throw new RuntimeException(e);
+		catch (IOException ex) {
+			throw new RuntimeException(ex);
 		}
 	}
 

--- a/src/main/java/com/canonical/devpackspring/setup/SetupModel.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupModel.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring.setup;
+
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Set;
+
+import org.yaml.snakeyaml.Yaml;
+
+public class SetupModel {
+
+	private final ArrayList<SetupCategory> categories;
+
+	public SetupModel(InputStreamReader reader) {
+		this.categories = new ArrayList<>();
+
+		Yaml yaml = new Yaml();
+		Map<String, Map<String, Object>> yamlData = yaml.load(reader);
+		Set<String> categories = yamlData.keySet();
+		for (var category : categories) {
+			var data = yamlData.get(category);
+			SetupCategory cat = new SetupCategory(category, data);
+			this.categories.add(cat);
+		}
+	}
+
+	public ArrayList<SetupCategory> getCategories() {
+		return categories;
+	}
+
+}

--- a/src/main/java/com/canonical/devpackspring/setup/SetupModel.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupModel.java
@@ -27,7 +27,7 @@ public class SetupModel {
 
 	private final ArrayList<SetupCategory> categories;
 
-	public SetupModel(InputStreamReader reader) {
+	public SetupModel(InputStreamReader reader, SetupEntryFactory factory) {
 		this.categories = new ArrayList<>();
 
 		Yaml yaml = new Yaml();
@@ -35,7 +35,7 @@ public class SetupModel {
 		Set<String> categories = yamlData.keySet();
 		for (var category : categories) {
 			var data = yamlData.get(category);
-			SetupCategory cat = new SetupCategory(category, data);
+			SetupCategory cat = new SetupCategory(factory, category, data);
 			this.categories.add(cat);
 		}
 	}

--- a/src/main/java/org/springframework/cli/command/SetupCommands.java
+++ b/src/main/java/org/springframework/cli/command/SetupCommands.java
@@ -44,13 +44,15 @@ public class SetupCommands {
 	private final TerminalMessage terminalMessage;
 
 	private final ComponentFlow.Builder componentFlowBuilder;
-    private final IProcessUtil processUtil;
 
-    @Autowired
-	public SetupCommands(TerminalMessage terminalMessage, ComponentFlow.Builder componentFlowBuilder, IProcessUtil processUtil) {
+	private final IProcessUtil processUtil;
+
+	@Autowired
+	public SetupCommands(TerminalMessage terminalMessage, ComponentFlow.Builder componentFlowBuilder,
+			IProcessUtil processUtil) {
 		this.terminalMessage = terminalMessage;
 		this.componentFlowBuilder = componentFlowBuilder;
-        this.processUtil = processUtil;
+		this.processUtil = processUtil;
 	}
 
 	@Command(command = "setup", description = "Setup development environment")
@@ -58,10 +60,10 @@ public class SetupCommands {
 		try (InputStreamReader ir = new InputStreamReader(
 				getClass().getResourceAsStream("/com/canonical/devpackspring/setup-configuration.yaml"))) {
 			SetupModel model = new SetupModel(ir, new SetupEntryFactory(processUtil));
-            if (add != null) {
-                headlessSetup(add, model);
-                return;
-            }
+			if (add != null) {
+				headlessSetup(add, model);
+				return;
+			}
 
 			ComponentFlow.Builder builder = componentFlowBuilder.clone().reset();
 			for (SetupCategory cat : model.getCategories()) {
@@ -85,22 +87,24 @@ public class SetupCommands {
 			ComponentFlow flow = builder.build();
 			ComponentFlow.ComponentFlowResult result = flow.run();
 			for (SetupCategory cat : model.getCategories()) {
-                HashSet<String> entrySet = new HashSet<>();
-                if (cat.isAllowMultiSelect()) {
-                    List<String> selectedEntries =  result.getContext().get(cat.getName());
-                    entrySet.addAll(selectedEntries);
-                } else {
-                    String selectedEntry =  result.getContext().get(cat.getName());
-                    entrySet.add(selectedEntry);
-                }
+				HashSet<String> entrySet = new HashSet<>();
+				if (cat.isAllowMultiSelect()) {
+					List<String> selectedEntries = result.getContext().get(cat.getName());
+					entrySet.addAll(selectedEntries);
+				}
+				else {
+					String selectedEntry = result.getContext().get(cat.getName());
+					entrySet.add(selectedEntry);
+				}
 
-                for (var entry : cat.getSetupEntries()) {
-                    if (entrySet.contains(entry.item())) {
-                        entry.install(terminalMessage);
-                    } else {
-                        entry.remove(terminalMessage);
-                    }
-                }
+				for (var entry : cat.getSetupEntries()) {
+					if (entrySet.contains(entry.item())) {
+						entry.install(terminalMessage);
+					}
+					else {
+						entry.remove(terminalMessage);
+					}
+				}
 			}
 		}
 		catch (IOException ex) {
@@ -109,19 +113,19 @@ public class SetupCommands {
 
 	}
 
-    private void headlessSetup(String[] add, SetupModel model) throws IOException {
-        HashSet<String> toAdd = new HashSet<>(Arrays.asList(add));
-        for (SetupCategory cat : model.getCategories()) {
-            for (SetupEntry entry : cat.getSetupEntries()) {
-                if (toAdd.contains(entry.item())) {
-                    entry.install(this.terminalMessage);
-                    toAdd.remove(entry.item());
-                }
-            }
-        }
-        for (var notInstalled : toAdd) {
-            terminalMessage.print(String.format("Not installed %s - the software item is not defined.", notInstalled));
-        }
-    }
+	private void headlessSetup(String[] add, SetupModel model) throws IOException {
+		HashSet<String> toAdd = new HashSet<>(Arrays.asList(add));
+		for (SetupCategory cat : model.getCategories()) {
+			for (SetupEntry entry : cat.getSetupEntries()) {
+				if (toAdd.contains(entry.item())) {
+					entry.install(this.terminalMessage);
+					toAdd.remove(entry.item());
+				}
+			}
+		}
+		for (var notInstalled : toAdd) {
+			terminalMessage.print(String.format("Not installed %s - the software item is not defined.", notInstalled));
+		}
+	}
 
 }

--- a/src/main/java/org/springframework/cli/command/SetupCommands.java
+++ b/src/main/java/org/springframework/cli/command/SetupCommands.java
@@ -23,8 +23,10 @@ import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 
+import com.canonical.devpackspring.IProcessUtil;
 import com.canonical.devpackspring.setup.SetupCategory;
 import com.canonical.devpackspring.setup.SetupEntry;
+import com.canonical.devpackspring.setup.SetupEntryFactory;
 import com.canonical.devpackspring.setup.SetupModel;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,18 +44,20 @@ public class SetupCommands {
 	private final TerminalMessage terminalMessage;
 
 	private final ComponentFlow.Builder componentFlowBuilder;
+    private final IProcessUtil processUtil;
 
-	@Autowired
-	public SetupCommands(TerminalMessage terminalMessage, ComponentFlow.Builder componentFlowBuilder) {
+    @Autowired
+	public SetupCommands(TerminalMessage terminalMessage, ComponentFlow.Builder componentFlowBuilder, IProcessUtil processUtil) {
 		this.terminalMessage = terminalMessage;
 		this.componentFlowBuilder = componentFlowBuilder;
+        this.processUtil = processUtil;
 	}
 
 	@Command(command = "setup", description = "Setup development environment")
 	public void setup(@Option(description = "Software to install") String[] add) {
 		try (InputStreamReader ir = new InputStreamReader(
 				getClass().getResourceAsStream("/com/canonical/devpackspring/setup-configuration.yaml"))) {
-			SetupModel model = new SetupModel(ir);
+			SetupModel model = new SetupModel(ir, new SetupEntryFactory(processUtil));
             if (add != null) {
                 headlessSetup(add, model);
                 return;

--- a/src/main/java/org/springframework/cli/command/SetupCommands.java
+++ b/src/main/java/org/springframework/cli/command/SetupCommands.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cli.command;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Comparator;
+
+import com.canonical.devpackspring.setup.SetupCategory;
+import com.canonical.devpackspring.setup.SetupModel;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cli.util.TerminalMessage;
+import org.springframework.shell.command.annotation.Command;
+import org.springframework.shell.component.flow.ComponentFlow;
+import org.springframework.shell.component.flow.ResultMode;
+import org.springframework.shell.component.flow.SelectItem;
+import org.springframework.shell.component.support.Nameable;
+
+public class SetupCommands {
+
+	private final TerminalMessage terminalMessage;
+
+	private final ComponentFlow.Builder componentFlowBuilder;
+
+	@Autowired
+	public SetupCommands(TerminalMessage terminalMessage, ComponentFlow.Builder componentFlowBuilder) {
+		this.terminalMessage = terminalMessage;
+		this.componentFlowBuilder = componentFlowBuilder;
+	}
+
+	@Command
+	public void setup() {
+		try (InputStreamReader ir = new InputStreamReader(
+				getClass().getResourceAsStream("/com/canonical/devpackspring/setup-configuration.yaml"))) {
+			SetupModel model = new SetupModel(ir);
+
+			ComponentFlow.Builder builder = componentFlowBuilder.clone();
+			for (SetupCategory cat : model.getCategories()) {
+				if (cat.isAllowMultiSelect()) {
+					builder = builder.withMultiItemSelector(cat.getName())
+						.selectItems(cat.getSetupEntries().stream().map(x -> (SelectItem) x).toList())
+						.name(cat.getName())
+						.sort(Comparator.comparing(Nameable::getName))
+						.resultValues(cat.getResultValues())
+						.resultMode(ResultMode.ACCEPT)
+						.and();
+				}
+				else {
+					builder = builder.withSingleItemSelector(cat.getName())
+						.selectItems(cat.getSetupEntries().stream().map(x -> (SelectItem) x).toList())
+						.name(cat.getName())
+						.sort(Comparator.comparing(Nameable::getName))
+						.resultValue(cat.getResultValues().get(0))
+						.resultMode(ResultMode.ACCEPT)
+						.and();
+				}
+			}
+			ComponentFlow flow = builder.build();
+			ComponentFlow.ComponentFlowResult result = flow.run();
+			for (SetupCategory cat : model.getCategories()) {
+				result.getContext().get(cat.getName());
+			}
+		}
+		catch (IOException ex) {
+			throw new RuntimeException(ex);
+		}
+
+	}
+
+}

--- a/src/main/java/org/springframework/cli/config/ProcessUtilProvider.java
+++ b/src/main/java/org/springframework/cli/config/ProcessUtilProvider.java
@@ -1,0 +1,16 @@
+package org.springframework.cli.config;
+
+import com.canonical.devpackspring.IProcessUtil;
+import com.canonical.devpackspring.ProcessUtil;
+import org.springframework.cli.util.TerminalMessage;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class ProcessUtilProvider implements IProcessUtil {
+    @Override
+    public int runProcess(TerminalMessage message, boolean inheritIO, String... args) throws IOException {
+        return ProcessUtil.runProcess(message, inheritIO, args);
+    }
+}

--- a/src/main/java/org/springframework/cli/config/ProcessUtilProvider.java
+++ b/src/main/java/org/springframework/cli/config/ProcessUtilProvider.java
@@ -1,16 +1,35 @@
-package org.springframework.cli.config;
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
-import com.canonical.devpackspring.IProcessUtil;
-import com.canonical.devpackspring.ProcessUtil;
-import org.springframework.cli.util.TerminalMessage;
-import org.springframework.stereotype.Component;
+package org.springframework.cli.config;
 
 import java.io.IOException;
 
+import com.canonical.devpackspring.IProcessUtil;
+import com.canonical.devpackspring.ProcessUtil;
+
+import org.springframework.cli.util.TerminalMessage;
+import org.springframework.stereotype.Component;
+
 @Component
 public class ProcessUtilProvider implements IProcessUtil {
-    @Override
-    public int runProcess(TerminalMessage message, boolean inheritIO, String... args) throws IOException {
-        return ProcessUtil.runProcess(message, inheritIO, args);
-    }
+
+	@Override
+	public int runProcess(TerminalMessage message, boolean inheritIO, String... args) throws IOException {
+		return ProcessUtil.runProcess(message, inheritIO, args);
+	}
+
 }

--- a/src/main/resources/META-INF/native-image/resource-config.json
+++ b/src/main/resources/META-INF/native-image/resource-config.json
@@ -68,6 +68,8 @@
     "pattern":"\\QMETA-INF/validation.xml\\E"
   }, {
     "pattern":"\\Qcom/canonical/devpackspring/plugin-configuration.yaml\\E"
+  },{
+    "pattern":"\\Qcom/canonical/devpackspring/setup-configuration.yaml\\E"
   }, {
     "pattern":"\\Qcom/sun/jna/linux-x86-64/libjnidispatch.so\\E"
   }, {

--- a/src/main/resources/com/canonical/devpackspring/setup-configuration.yaml
+++ b/src/main/resources/com/canonical/devpackspring/setup-configuration.yaml
@@ -1,4 +1,5 @@
 java:
+  description: OpenJDK
   multiselect: true
   apt:
     - openjdk-8-jdk:
@@ -10,7 +11,7 @@ java:
     - openjdk-21-jdk:
         description: OpenJDK 21
 docker:
-  multiselect: false
+  description: Container environment
   apt:
     - docker.io:
         description: docker.io - Docker container runtime
@@ -29,17 +30,24 @@ docker:
           - sudo snap disable docker
           - sudo snap enable docker
 ide:
+  description: Integrated Development Environment
   multiselect: true
   snap:
     - intellij-idea-community:
         description: Intellij Idea Community snap
     - eclipse:
         description: Eclipse snap
-    - vscode:
-        description: VScode snap
+    - code:
+        description: Visual Studio Code snap
         extra-commands:
           - code --install-extension redhat.java
-vcs:
+misc:
+  description: Additional tools
+  snap:
+    - snapcraft:
+        description: snapcraft - easily create snaps
+    - rockcraft:
+        description: rockcraft - a craft like experience to create rocks
   apt:
     - git:
         description: git - fast, scalable, distributed revision control system

--- a/src/main/resources/com/canonical/devpackspring/setup-configuration.yaml
+++ b/src/main/resources/com/canonical/devpackspring/setup-configuration.yaml
@@ -1,0 +1,45 @@
+java:
+  multiselect: true
+  apt:
+    - openjdk-8-jdk:
+        description: OpenJDK 8
+    - openjdk-11-jdk:
+        description: OpenJDK 11
+    - openjdk-17-jdk:
+        description: OpenJDK 17
+    - openjdk-21-jdk:
+        description: OpenJDK 21
+docker:
+  multiselect: false
+  apt:
+    - docker.io:
+        description: docker.io - Docker container runtime
+    - podman:
+        description: podman - A daemon-less alternative to docker
+  snap:
+    - docker:
+        description: docker - Docker container runtime snap
+        extra-commands:
+          - sudo snap connect docker:privileged :docker-support
+          - sudo snap connect docker:support :docker-support
+          - sudo snap connect docker:firewall-control :firewall-control
+          - sudo snap connect docker:network-control :network-control
+          - sudo snap connect docker:docker-cli docker:docker-daemon
+          - sudo snap connect docker:home
+          - sudo snap disable docker
+          - sudo snap enable docker
+ide:
+  multiselect: true
+  snap:
+    - intellij-idea-community:
+        description: Intellij Idea Community snap
+    - eclipse:
+        description: Eclipse snap
+    - vscode:
+        description: VScode snap
+        extra-commands:
+          - code --install-extension redhat.java
+vcs:
+  apt:
+    - git:
+        description: git - fast, scalable, distributed revision control system

--- a/src/test/java/com/canonical/devpackspring/setup/SetupModelTests.java
+++ b/src/test/java/com/canonical/devpackspring/setup/SetupModelTests.java
@@ -29,9 +29,8 @@ public class SetupModelTests {
 	public void testParseSetupModel() throws IOException {
 		try (InputStreamReader ir = new InputStreamReader(
 				getClass().getResourceAsStream("/com/canonical/devpackspring/setup-configuration.yaml"))) {
-			SetupModel model = new SetupModel(ir);
+			SetupModel model = new SetupModel(ir, new SetupEntryFactory(null));
 			assertThat(model.getCategories().stream().map(x -> x.getName())).contains("java", "docker", "ide", "vcs");
-
 		}
 	}
 

--- a/src/test/java/com/canonical/devpackspring/setup/SetupModelTests.java
+++ b/src/test/java/com/canonical/devpackspring/setup/SetupModelTests.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring.setup;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SetupModelTests {
+
+	@Test
+	public void testParseSetupModel() throws IOException {
+		try (InputStreamReader ir = new InputStreamReader(
+				getClass().getResourceAsStream("/com/canonical/devpackspring/setup-configuration.yaml"))) {
+			SetupModel model = new SetupModel(ir);
+			assertThat(model.getCategories().stream().map(x -> x.getName())).contains("java", "docker", "ide", "vcs");
+
+		}
+	}
+
+}

--- a/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
+++ b/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cli.command;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.cli.support.MockConfigurations;
+import org.springframework.cli.util.StubTerminalMessage;
+import org.springframework.shell.component.flow.ComponentFlow;
+
+public class SetupCommandsTests {
+
+	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+		.withUserConfiguration(MockConfigurations.MockBaseConfig.class);
+
+	@Test
+	public void testSetupCommands() {
+		this.contextRunner.withUserConfiguration(MockConfigurations.MockUserConfig.class).run((context) -> {
+			StubTerminalMessage stub = new StubTerminalMessage();
+			SetupCommands setupCommands = new SetupCommands(stub, ComponentFlow.builder());
+			setupCommands.setup();
+
+		});
+	}
+
+}


### PR DESCRIPTION
This PR adds `devpack-for-spring-cli setup` command that allows to set up development environment. 

The command reads yaml configuration file and runs `apt` or `snap` setup commands to install selected software and remove unselected one. 

The followup MR will add ability to read configuration from the user's home / location set in the environment variable.
