### PR TITLE
feat: allow external configuration

### DIFF
--- a/src/main/java/com/canonical/devpackspring/ConfigUtil.java
+++ b/src/main/java/com/canonical/devpackspring/ConfigUtil.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2025 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring;
+
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Opens configuration stream
+ */
+public abstract class ConfigUtil {
+
+	/**
+	 * Opens configuration file stream
+	 * @param environment - environment variable specifying path to the file
+	 * @param fileName - configuration file name
+	 * @return configuration file InputStream
+	 * @throws FileNotFoundException - configuration file not found
+	 */
+	public static InputStream openConfigurationFile(String environment, String fileName) throws FileNotFoundException {
+		String pluginConfigurationFile = System.getenv(environment);
+		if (pluginConfigurationFile == null) {
+			pluginConfigurationFile = System.getProperty(environment);
+		}
+		if (pluginConfigurationFile != null) {
+			return new FileInputStream(pluginConfigurationFile);
+		}
+		Path configPath = Path.of(System.getProperty("user.home"))
+			.resolve(".config")
+			.resolve("devpack-for-spring")
+			.resolve(fileName);
+		if (Files.exists(configPath)) {
+			return new FileInputStream(configPath.toFile());
+		}
+
+		return ConfigUtil.class.getResourceAsStream(String.format("/com/canonical/devpackspring/%s", fileName));
+	}
+
+}

--- a/src/main/java/org/springframework/cli/command/BuildCommands.java
+++ b/src/main/java/org/springframework/cli/command/BuildCommands.java
@@ -16,7 +16,6 @@
 
 package org.springframework.cli.command;
 
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -26,6 +25,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Stream;
 
+import com.canonical.devpackspring.ConfigUtil;
 import com.canonical.devpackspring.build.BuildSystem;
 import com.canonical.devpackspring.build.PluginDescriptor;
 import com.canonical.devpackspring.build.PluginDescriptorContainer;
@@ -82,14 +82,7 @@ public class BuildCommands {
 	}
 
 	private InputStream getPluginConfiguration() throws IOException {
-		String pluginConfigurationFile = System.getenv(PLUGIN_CONFIGURATION);
-		if (pluginConfigurationFile == null) {
-			pluginConfigurationFile = System.getProperty(PLUGIN_CONFIGURATION);
-		}
-		if (pluginConfigurationFile != null) {
-			return new FileInputStream(pluginConfigurationFile);
-		}
-		return getClass().getResourceAsStream("/com/canonical/devpackspring/plugin-configuration.yaml");
+		return ConfigUtil.openConfigurationFile(PLUGIN_CONFIGURATION, "plugin-configuration.yaml");
 	}
 
 	@Command(command = "plugin", description = "Run a build plugin for the project")

--- a/src/main/java/org/springframework/cli/command/SetupCommands.java
+++ b/src/main/java/org/springframework/cli/command/SetupCommands.java
@@ -16,13 +16,16 @@
 
 package org.springframework.cli.command;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 
+import com.canonical.devpackspring.ConfigUtil;
 import com.canonical.devpackspring.IProcessUtil;
 import com.canonical.devpackspring.setup.SetupCategory;
 import com.canonical.devpackspring.setup.SetupEntry;
@@ -41,6 +44,8 @@ import org.springframework.shell.component.support.Nameable;
 @Command
 public class SetupCommands {
 
+	public static final String SETUP_CONFIGURATION = "SPRING_CLI_SETUP_COMMANDS_CONFIGURATION";
+
 	private final TerminalMessage terminalMessage;
 
 	private final ComponentFlow.Builder componentFlowBuilder;
@@ -57,8 +62,7 @@ public class SetupCommands {
 
 	@Command(command = "setup", description = "Setup development environment")
 	public void setup(@Option(description = "Software to install") String[] add) {
-		try (InputStreamReader ir = new InputStreamReader(
-				getClass().getResourceAsStream("/com/canonical/devpackspring/setup-configuration.yaml"))) {
+		try (InputStreamReader ir = new InputStreamReader(getSetupConfiguration())) {
 			SetupModel model = new SetupModel(ir, new SetupEntryFactory(processUtil));
 			if (add != null) {
 				headlessSetup(add, model);
@@ -126,6 +130,10 @@ public class SetupCommands {
 		for (var notInstalled : toAdd) {
 			terminalMessage.print(String.format("Not installed %s - the software item is not defined.", notInstalled));
 		}
+	}
+
+	private InputStream getSetupConfiguration() throws FileNotFoundException {
+		return ConfigUtil.openConfigurationFile(SETUP_CONFIGURATION, "setup-configuration.yaml");
 	}
 
 }

--- a/src/test/java/com/canonical/devpackspring/ConfigUtilTests.java
+++ b/src/test/java/com/canonical/devpackspring/ConfigUtilTests.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2022-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ConfigUtilTests {
+
+	@TempDir
+	private Path tempDir;
+
+	@Test
+	public void testEmbeddedConfig() throws IOException {
+		assertThat(ConfigUtil.openConfigurationFile("foo", "plugin-configuration.yaml")).isNotNull();
+		assertThat(ConfigUtil.openConfigurationFile("foo", "plugin-configuration.yaml1")).isNull();
+	}
+
+	@Test
+	public void testUserHomeConfig() throws IOException {
+		System.setProperty("user.home", tempDir.toString());
+		Path where = tempDir.resolve(".config").resolve("devpack-for-spring");
+		Files.createDirectories(where);
+		Files.writeString(where.resolve("foo.yaml"), "test");
+		assertThat(ConfigUtil.openConfigurationFile("foo", "foo.yaml")).isNotNull();
+	}
+
+	@Test
+	public void testEnvironmentConfig() throws IOException {
+		Path where = tempDir.resolve("env.yaml");
+		Files.writeString(where, "test");
+		System.setProperty("foo", where.toString());
+
+		assertThat(ConfigUtil.openConfigurationFile("foo", "foo.yaml")).isNotNull();
+	}
+
+}


### PR DESCRIPTION
- read system environment / Java property SPRING_CLI_BUILD_COMMANDS_PLUGIN_CONFIGURATION SPRING_CLI_SETUP_COMMANDS_CONFIGURATION
- read configuration file from ~/.config/devpack-for-spring
- read embedded yaml file