### PR TITLE
fix: apply configuration to subprojects

### DIFF
--- a/src/main/java/com/canonical/devpackspring/build/gradle/Refactoring.java
+++ b/src/main/java/com/canonical/devpackspring/build/gradle/Refactoring.java
@@ -64,6 +64,7 @@ public final class Refactoring {
 		recipes.add(new AddGradlePluginRecipe(id, version, kotlin));
 
 		if (configuration != null) {
+			configuration = String.format("%s\nsubprojects {\n%s\n}", configuration, configuration);
 			var tempDir = Path.of(System.getProperty("java.io.tmpdir"));
 			Path dummyPath = tempDir.resolve(kotlin ? "build.gradle.kts" : "build.gradle");
 			SourceFile configSourceFile = parser

--- a/src/main/java/com/canonical/devpackspring/build/gradle/Refactoring.java
+++ b/src/main/java/com/canonical/devpackspring/build/gradle/Refactoring.java
@@ -64,7 +64,9 @@ public final class Refactoring {
 		recipes.add(new AddGradlePluginRecipe(id, version, kotlin));
 
 		if (configuration != null) {
-			configuration = String.format("%s\nsubprojects {\n%s\n}", configuration, configuration);
+			var withId = kotlin ? String.format("plugins.withId('%s'){\n%s\n}\n", id, configuration) :
+					String.format("plugins.withId(\"%s\"){\n%s\n}\n", id, configuration);
+			configuration = String.format("%s\nsubprojects {\n%s\n}", configuration, withId);
 			var tempDir = Path.of(System.getProperty("java.io.tmpdir"));
 			Path dummyPath = tempDir.resolve(kotlin ? "build.gradle.kts" : "build.gradle");
 			SourceFile configSourceFile = parser

--- a/src/main/java/com/canonical/devpackspring/build/gradle/Refactoring.java
+++ b/src/main/java/com/canonical/devpackspring/build/gradle/Refactoring.java
@@ -64,8 +64,8 @@ public final class Refactoring {
 		recipes.add(new AddGradlePluginRecipe(id, version, kotlin));
 
 		if (configuration != null) {
-			var withId = kotlin ? String.format("plugins.withId('%s'){\n%s\n}\n", id, configuration) :
-					String.format("plugins.withId(\"%s\"){\n%s\n}\n", id, configuration);
+			var withId = kotlin ? String.format("plugins.withId(\"%s\"){\n%s\n}\n", id, configuration)
+					: String.format("plugins.withId('%s'){\n%s\n}\n", id, configuration);
 			configuration = String.format("%s\nsubprojects {\n%s\n}", configuration, withId);
 			var tempDir = Path.of(System.getProperty("java.io.tmpdir"));
 			Path dummyPath = tempDir.resolve(kotlin ? "build.gradle.kts" : "build.gradle");

--- a/src/test/java/com/canonical/devpackspring/build/gradle/RefactoringTests.java
+++ b/src/test/java/com/canonical/devpackspring/build/gradle/RefactoringTests.java
@@ -84,14 +84,14 @@ public class RefactoringTests {
 			Path buildFile = workingDir.resolve("build.gradle.kts");
 			String kotlinSnippet = "configure<com.example.MyOptions> {\n    setTargetRelease(21)\n}";
 			PluginDescriptor desc = new PluginDescriptor("foo", "1.0.0", null, null,
-					new PluginTasks(Collections.emptyMap()),
-					new PluginConfiguration(null, null, kotlinSnippet, null), null);
+					new PluginTasks(Collections.emptyMap()), new PluginConfiguration(null, null, kotlinSnippet, null),
+					null);
 
 			Refactoring.configurePlugin(new StubTerminalMessage(), desc, buildFile);
 
 			assertThat(buildFile).content().contains("id(\"foo\") version \"1.0.0\"");
 			assertThat(buildFile).content().contains("subprojects {");
-			assertThat(buildFile).content().contains("plugins.withId('foo'){");
+			assertThat(buildFile).content().contains("plugins.withId(\"foo\"){");
 		});
 	}
 

--- a/src/test/java/com/canonical/devpackspring/build/gradle/RefactoringTests.java
+++ b/src/test/java/com/canonical/devpackspring/build/gradle/RefactoringTests.java
@@ -76,4 +76,23 @@ public class RefactoringTests {
 		});
 	}
 
+	@Test
+	public void testRefactoringWithConfigBlock(final @TempDir Path workingDir) {
+		Path projectPath = Path.of("test-data").resolve("projects").resolve("gradle-kotlin");
+		IntegrationTestSupport.installInWorkingDirectory(projectPath, workingDir);
+		contextRunner.withUserConfiguration(MockConfigurations.MockUserConfig.class).run(context -> {
+			Path buildFile = workingDir.resolve("build.gradle.kts");
+			String kotlinSnippet = "configure<com.example.MyOptions> {\n    setTargetRelease(21)\n}";
+			PluginDescriptor desc = new PluginDescriptor("foo", "1.0.0", null, null,
+					new PluginTasks(Collections.emptyMap()),
+					new PluginConfiguration(null, null, kotlinSnippet, null), null);
+
+			Refactoring.configurePlugin(new StubTerminalMessage(), desc, buildFile);
+
+			assertThat(buildFile).content().contains("id(\"foo\") version \"1.0.0\"");
+			assertThat(buildFile).content().contains("subprojects {");
+			assertThat(buildFile).content().contains("plugins.withId('foo'){");
+		});
+	}
+
 }


### PR DESCRIPTION
Note: the change does not introduce new regressions. I have considered adding a multi-module integration test, but it will be low value - it will increase the pipeline runtime, but will still  have problem of overriding existing plugin configuration in subprojects, potentially causing build breaks. 
