### PR TITLE
feat: add uninstall option to setup command

### DIFF
--- a/src/main/java/org/springframework/cli/command/SetupCommands.java
+++ b/src/main/java/org/springframework/cli/command/SetupCommands.java
@@ -97,8 +97,7 @@ public class SetupCommands {
 			}
 			ComponentFlow flow = builder.build();
 			ComponentFlow.ComponentFlowResult result = flow.run();
-			uninstall = result.getContext().get("uninstall");
-
+			uninstall = uninstall || Boolean.TRUE.equals(result.getContext().get("uninstall"));
 			for (SetupCategory cat : model.getCategories()) {
 				HashSet<String> entrySet = new HashSet<>();
 				if (cat.isAllowMultiSelect()) {

--- a/src/main/java/org/springframework/cli/command/SetupCommands.java
+++ b/src/main/java/org/springframework/cli/command/SetupCommands.java
@@ -61,11 +61,12 @@ public class SetupCommands {
 	}
 
 	@Command(command = "setup", description = "Setup development environment")
-	public void setup(@Option(description = "Software to install") String[] add) {
+	public void setup(@Option(description = "Software to install") String[] add,
+			@Option(description = "Uninstall unselected options", defaultValue = "false") boolean uninstall) {
 		try (InputStreamReader ir = new InputStreamReader(getSetupConfiguration())) {
 			SetupModel model = new SetupModel(ir, new SetupEntryFactory(processUtil));
 			if (add != null) {
-				headlessSetup(add, model);
+				headlessSetup(add, model, uninstall);
 				return;
 			}
 
@@ -105,7 +106,7 @@ public class SetupCommands {
 					if (entrySet.contains(entry.item())) {
 						entry.install(terminalMessage);
 					}
-					else {
+					else if (uninstall) {
 						entry.remove(terminalMessage);
 					}
 				}
@@ -117,13 +118,16 @@ public class SetupCommands {
 
 	}
 
-	private void headlessSetup(String[] add, SetupModel model) throws IOException {
+	private void headlessSetup(String[] add, SetupModel model, boolean uninstall) throws IOException {
 		HashSet<String> toAdd = new HashSet<>(Arrays.asList(add));
 		for (SetupCategory cat : model.getCategories()) {
 			for (SetupEntry entry : cat.getSetupEntries()) {
 				if (toAdd.contains(entry.item())) {
 					entry.install(this.terminalMessage);
 					toAdd.remove(entry.item());
+				}
+				else if (uninstall) {
+					entry.remove(this.terminalMessage);
 				}
 			}
 		}

--- a/src/main/java/org/springframework/cli/command/SetupCommands.java
+++ b/src/main/java/org/springframework/cli/command/SetupCommands.java
@@ -90,9 +90,9 @@ public class SetupCommands {
 				}
 			}
 			builder = builder.withConfirmationInput("uninstall")
-					.name("Remove unselected software?")
-					.defaultValue(false)
-					.and();
+				.name("Remove unselected software?")
+				.defaultValue(false)
+				.and();
 			ComponentFlow flow = builder.build();
 			ComponentFlow.ComponentFlowResult result = flow.run();
 			uninstall = result.getContext().get("uninstall");

--- a/src/main/java/org/springframework/cli/command/SetupCommands.java
+++ b/src/main/java/org/springframework/cli/command/SetupCommands.java
@@ -157,6 +157,9 @@ public class SetupCommands {
 	}
 
 	private interface Operation {
+
 		void run() throws IOException;
+
 	}
+
 }

--- a/src/main/java/org/springframework/cli/command/SetupCommands.java
+++ b/src/main/java/org/springframework/cli/command/SetupCommands.java
@@ -89,8 +89,14 @@ public class SetupCommands {
 						.and();
 				}
 			}
+			builder = builder.withConfirmationInput("uninstall")
+					.name("Remove unselected software?")
+					.defaultValue(false)
+					.and();
 			ComponentFlow flow = builder.build();
 			ComponentFlow.ComponentFlowResult result = flow.run();
+			uninstall = result.getContext().get("uninstall");
+
 			for (SetupCategory cat : model.getCategories()) {
 				HashSet<String> entrySet = new HashSet<>();
 				if (cat.isAllowMultiSelect()) {

--- a/src/main/java/org/springframework/cli/command/SetupCommands.java
+++ b/src/main/java/org/springframework/cli/command/SetupCommands.java
@@ -89,10 +89,12 @@ public class SetupCommands {
 						.and();
 				}
 			}
-			builder = builder.withConfirmationInput("uninstall")
-				.name("Remove unselected software?")
-				.defaultValue(false)
-				.and();
+			if (!uninstall) {
+				builder = builder.withConfirmationInput("uninstall")
+					.name("Remove unselected software?")
+					.defaultValue(false)
+					.and();
+			}
 			ComponentFlow flow = builder.build();
 			ComponentFlow.ComponentFlowResult result = flow.run();
 			uninstall = result.getContext().get("uninstall");

--- a/src/main/java/org/springframework/cli/command/SetupCommands.java
+++ b/src/main/java/org/springframework/cli/command/SetupCommands.java
@@ -20,6 +20,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -127,19 +128,27 @@ public class SetupCommands {
 
 	private void headlessSetup(String[] add, SetupModel model, boolean uninstall) throws IOException {
 		HashSet<String> toAdd = new HashSet<>(Arrays.asList(add));
+		ArrayList<Operation> operators = new ArrayList<>();
 		for (SetupCategory cat : model.getCategories()) {
 			for (SetupEntry entry : cat.getSetupEntries()) {
 				if (toAdd.contains(entry.item())) {
-					entry.install(this.terminalMessage);
+					operators.add(() -> entry.install(this.terminalMessage));
 					toAdd.remove(entry.item());
 				}
 				else if (uninstall) {
-					entry.remove(this.terminalMessage);
+					operators.add(() -> entry.remove(this.terminalMessage));
 				}
 			}
 		}
 		for (var notInstalled : toAdd) {
 			terminalMessage.print(String.format("Not installed %s - the software item is not defined.", notInstalled));
+		}
+		if (!toAdd.isEmpty()) {
+			throw new IOException("Missing software item definitions");
+		}
+		// install and uninstall
+		for (var operator : operators) {
+			operator.run();
 		}
 	}
 
@@ -147,4 +156,7 @@ public class SetupCommands {
 		return ConfigUtil.openConfigurationFile(SETUP_CONFIGURATION, "setup-configuration.yaml");
 	}
 
+	private interface Operation {
+		void run() throws IOException;
+	}
 }

--- a/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
+++ b/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
@@ -35,6 +35,7 @@ import org.springframework.shell.component.context.ComponentContext;
 import org.springframework.shell.component.flow.ComponentFlow;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.AdditionalMatchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -58,7 +59,10 @@ public class SetupCommandsTests {
 		this.contextRunner.withUserConfiguration(MockConfigurations.MockUserConfig.class).run((context) -> {
 			StubTerminalMessage stub = new StubTerminalMessage();
 			SetupCommands setupCommands = new SetupCommands(stub, ComponentFlow.builder(), mockProcessUtil);
-			setupCommands.setup(new String[] { "foo", "bar" }, false);
+			assertThatThrownBy(() -> setupCommands.setup(new String[] { "foo", "bar" }, false))
+				.isInstanceOf(RuntimeException.class)
+				.hasCauseInstanceOf(IOException.class)
+				.hasMessageContaining("Missing software item definitions");
 			assertThat(stub.getPrintMessages()).contains("Not installed foo - the software item is not defined.",
 					"Not installed bar - the software item is not defined.");
 

--- a/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
+++ b/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
@@ -288,6 +288,43 @@ public class SetupCommandsTests {
 				eq(aptPackage));
 	}
 
+	@Test
+	public void testWizardWithUninstallOption() throws IOException {
+		String aptPackage = "openjdk-17-jdk";
+		String aptCheckPattern = "dpkg -s " + aptPackage;
+		given(mockProcessUtil.runProcess(any(), anyBoolean(), any(), any(), contains(aptCheckPattern))).willReturn(0);
+		given(mockProcessUtil.runProcess(any(), anyBoolean(), any(), any(), not(contains(aptCheckPattern))))
+			.willReturn(1);
+		given(mockProcessUtil.runProcess(any(), anyBoolean(), eq("sudo"), eq("apt-get"), eq("remove"), eq("-y"),
+				eq(aptPackage)))
+			.willReturn(0);
+		ComponentContext<?> mockContext = Mockito.mock(ComponentContext.class);
+		Mockito.doReturn(List.of()).when(mockContext).get("java");
+		setupMultiselect(mockContext);
+
+		// no confirmation dialog should be shown - return null for uninstall key
+		Mockito.doReturn(null).when(mockContext).get("uninstall");
+
+		ComponentFlow.ComponentFlowResult mockResult = Mockito.mock(ComponentFlow.ComponentFlowResult.class);
+		Mockito.doReturn(mockContext).when(mockResult).getContext();
+
+		ComponentFlow mockFlow = Mockito.mock(ComponentFlow.class);
+		given(mockFlow.run()).willReturn(mockResult);
+
+		ComponentFlow.Builder mockBuilder = createMockBuilder(mockFlow);
+
+		var setupCommands = new SetupCommands(new StubTerminalMessage(), mockBuilder, mockProcessUtil);
+		// null add, uninstall true → wizard path
+		setupCommands.setup(null, true);
+
+		// openjdk-17-jdk was installed and not selected → must be removed because uninstall defaults to true
+		verify(mockProcessUtil).runProcess(any(), anyBoolean(), eq("sudo"), eq("apt-get"), eq("remove"), eq("-y"),
+				eq(aptPackage));
+
+		// Check that withConfirmationInput is not called on the builder
+		verify(mockBuilder, never()).withConfirmationInput(any());
+	}
+
 	private static void setupMultiselect(ComponentContext<?> mockContext) {
 		Mockito.doReturn(List.of()).when(mockContext).get("docker");
 		Mockito.doReturn(List.of()).when(mockContext).get("ide");

--- a/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
+++ b/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
@@ -403,7 +403,7 @@ public class SetupCommandsTests {
 			this.contextRunner.withUserConfiguration(MockConfigurations.MockUserConfig.class).run((context) -> {
 				StubTerminalMessage stub = new StubTerminalMessage();
 				SetupCommands setupCommands = new SetupCommands(stub, ComponentFlow.builder(), mockProcessUtil);
-				setupCommands.setup(new String[] { "openjdk-17", "openjdk-21" }, null, null, false);
+				setupCommands.setup(new String[] { "openjdk-17-jdk", "openjdk-21-jdk" }, null, null, false);
 
 				Path expectedPath = tempDir.resolve(".config")
 					.resolve("devpack-for-spring")
@@ -411,10 +411,11 @@ public class SetupCommandsTests {
 
 				assertThat(expectedPath).exists();
 				String content = Files.readString(expectedPath);
-				assertThat(content).contains("openjdk-17").contains("openjdk-21");
+				assertThat(content).contains("openjdk-17-jdk").contains("openjdk-21-jdk");
 				File installFile = File.createTempFile("install", ".tmp");
 				installFile.deleteOnExit();
-				setupCommands.setup(new String[] { "openjdk-17", "openjdk-21" }, null, installFile.toPath(), false);
+				setupCommands.setup(new String[] { "openjdk-17-jdk", "openjdk-21-jdk" }, null, installFile.toPath(),
+						false);
 				assertThat(installFile).exists();
 
 			});
@@ -432,7 +433,11 @@ public class SetupCommandsTests {
 		this.contextRunner.withUserConfiguration(MockConfigurations.MockUserConfig.class).run((context) -> {
 			StubTerminalMessage stub = new StubTerminalMessage();
 			SetupCommands setupCommands = new SetupCommands(stub, ComponentFlow.builder(), mockProcessUtil);
-			setupCommands.setup(null, configPath, tempPath, false);
+			assertThatThrownBy(() -> setupCommands.setup(null, configPath, tempPath, false))
+				.isInstanceOf(RuntimeException.class)
+				.hasCauseInstanceOf(IOException.class)
+				.hasMessageContaining("Missing software item definitions");
+
 			assertThat(stub.getPrintMessages()).contains("Not installed foo - the software item is not defined.",
 					"Not installed bar - the software item is not defined.");
 		});

--- a/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
+++ b/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
@@ -306,9 +306,6 @@ public class SetupCommandsTests {
 		Mockito.doReturn(List.of()).when(mockContext).get("java");
 		setupMultiselect(mockContext);
 
-		// no confirmation dialog should be shown - return null for uninstall key
-		Mockito.doReturn(null).when(mockContext).get("uninstall");
-
 		ComponentFlow.ComponentFlowResult mockResult = Mockito.mock(ComponentFlow.ComponentFlowResult.class);
 		Mockito.doReturn(mockContext).when(mockResult).getContext();
 

--- a/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
+++ b/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
@@ -317,7 +317,8 @@ public class SetupCommandsTests {
 		// null add, uninstall true → wizard path
 		setupCommands.setup(null, true);
 
-		// openjdk-17-jdk was installed and not selected → must be removed because uninstall defaults to true
+		// openjdk-17-jdk was installed and not selected → must be removed because
+		// uninstall defaults to true
 		verify(mockProcessUtil).runProcess(any(), anyBoolean(), eq("sudo"), eq("apt-get"), eq("remove"), eq("-y"),
 				eq(aptPackage));
 

--- a/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
+++ b/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
@@ -173,7 +173,7 @@ public class SetupCommandsTests {
 		String snapPackage = "docker";
 		String snapInstallPattern = "snap info " + snapPackage;
 
-		// Report only openjdk-17-jdk as installed
+		// Report only docker as installed
 		given(mockProcessUtil.runProcess(any(), anyBoolean(), any(), any(), contains(snapInstallPattern)))
 			.willReturn(0);
 		given(mockProcessUtil.runProcess(any(), anyBoolean(), any(), any(), not(contains(snapInstallPattern))))
@@ -197,7 +197,7 @@ public class SetupCommandsTests {
 	@Test
 	public void testUninstallSkippedWhenNotInstalled() throws IOException {
 		// When uninstall=true but the package is not currently installed,
-		// remove() should return early without invoking any process.
+		// remove() should return early without invoking any removal process.
 		String toRemove = "openjdk-17-jdk";
 
 		StubTerminalMessage tm = new StubTerminalMessage();
@@ -248,25 +248,22 @@ public class SetupCommandsTests {
 		SetupCommands setupCommands = new SetupCommands(tm, mockBuilder, mockProcessUtil);
 		setupCommands.setup(null, false);
 
-		assertThat(tm.getPrintMessages())
-			.contains(String.format("%s was successfully installed.", description));
+		assertThat(tm.getPrintMessages()).contains(String.format("%s was successfully installed.", description));
 		// no package should have been removed
-		verify(mockProcessUtil, never()).runProcess(any(), anyBoolean(), eq("sudo"), eq("apt-get"),
-				eq("remove"), eq("-y"), any());
-		verify(mockProcessUtil, never()).runProcess(any(), anyBoolean(), eq("sudo"), eq("snap"),
-				eq("remove"), any());
+		verify(mockProcessUtil, never()).runProcess(any(), anyBoolean(), eq("sudo"), eq("apt-get"), eq("remove"),
+				eq("-y"), any());
+		verify(mockProcessUtil, never()).runProcess(any(), anyBoolean(), eq("sudo"), eq("snap"), eq("remove"), any());
 	}
 
 	@Test
 	public void testWizardConfirmationUninstall() throws IOException {
 		String aptPackage = "openjdk-17-jdk";
 		String aptCheckPattern = "dpkg -s " + aptPackage;
-		given(mockProcessUtil.runProcess(any(), anyBoolean(), any(), any(), contains(aptCheckPattern)))
-			.willReturn(0);
+		given(mockProcessUtil.runProcess(any(), anyBoolean(), any(), any(), contains(aptCheckPattern))).willReturn(0);
 		given(mockProcessUtil.runProcess(any(), anyBoolean(), any(), any(), not(contains(aptCheckPattern))))
 			.willReturn(1);
-		given(mockProcessUtil.runProcess(any(), anyBoolean(), eq("sudo"), eq("apt-get"), eq("remove"),
-				eq("-y"), eq(aptPackage)))
+		given(mockProcessUtil.runProcess(any(), anyBoolean(), eq("sudo"), eq("apt-get"), eq("remove"), eq("-y"),
+				eq(aptPackage)))
 			.willReturn(0);
 		ComponentContext<?> mockContext = Mockito.mock(ComponentContext.class);
 		Mockito.doReturn(List.of()).when(mockContext).get("java");
@@ -287,8 +284,8 @@ public class SetupCommandsTests {
 		setupCommands.setup(null, false);
 
 		// openjdk-17-jdk was installed and not selected → must be removed
-		verify(mockProcessUtil).runProcess(any(), anyBoolean(), eq("sudo"), eq("apt-get"),
-				eq("remove"), eq("-y"), eq(aptPackage));
+		verify(mockProcessUtil).runProcess(any(), anyBoolean(), eq("sudo"), eq("apt-get"), eq("remove"), eq("-y"),
+				eq(aptPackage));
 	}
 
 	private static void setupMultiselect(ComponentContext<?> mockContext) {
@@ -299,7 +296,9 @@ public class SetupCommandsTests {
 
 	private ComponentFlow.Builder createMockBuilder(ComponentFlow mockFlow) {
 		class BuilderHolder {
+
 			ComponentFlow.Builder builder;
+
 		}
 		final BuilderHolder holder = new BuilderHolder();
 		Answer<Object> builderAnswer = new Answer<Object>() {

--- a/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
+++ b/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
@@ -30,11 +30,14 @@ import org.springframework.cli.util.StubTerminalMessage;
 import org.springframework.shell.component.flow.ComponentFlow;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.AdditionalMatchers.not;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 public class SetupCommandsTests {
@@ -50,7 +53,7 @@ public class SetupCommandsTests {
 		this.contextRunner.withUserConfiguration(MockConfigurations.MockUserConfig.class).run((context) -> {
 			StubTerminalMessage stub = new StubTerminalMessage();
 			SetupCommands setupCommands = new SetupCommands(stub, ComponentFlow.builder(), mockProcessUtil);
-			setupCommands.setup(new String[] { "foo", "bar" });
+			setupCommands.setup(new String[] { "foo", "bar" }, false);
 			assertThat(stub.getPrintMessages()).contains("Not installed foo - the software item is not defined.",
 					"Not installed bar - the software item is not defined.");
 
@@ -69,7 +72,7 @@ public class SetupCommandsTests {
 		given(mockProcessUtil.runProcess(any(), anyBoolean(), any(), any(), contains("| grep -q \"installed:\"")))
 			.willReturn(0);
 		SetupCommands setupCommands = new SetupCommands(tm, ComponentFlow.builder(), mockProcessUtil);
-		setupCommands.setup(new String[] { toInstall });
+		setupCommands.setup(new String[] { toInstall }, false);
 		assertThat(tm.getPrintMessages()).contains(String.format("%s was successfully installed.", description));
 	}
 
@@ -92,7 +95,7 @@ public class SetupCommandsTests {
 			.willReturn(1);
 
 		SetupCommands setupCommands = new SetupCommands(tm, ComponentFlow.builder(), mockProcessUtil);
-		setupCommands.setup(new String[] { toInstall });
+		setupCommands.setup(new String[] { toInstall }, false);
 		assertThat(tm.getPrintAttributedMessages()).contains(String.format("Failed to install package %s.", toInstall));
 	}
 
@@ -109,7 +112,7 @@ public class SetupCommandsTests {
 			.willReturn(1);
 
 		SetupCommands setupCommands = new SetupCommands(tm, ComponentFlow.builder(), mockProcessUtil);
-		setupCommands.setup(new String[] { toInstall });
+		setupCommands.setup(new String[] { toInstall }, false);
 		assertThat(tm.getPrintMessages()).contains(String.format("%s was successfully installed.", description));
 	}
 
@@ -128,8 +131,87 @@ public class SetupCommandsTests {
 			.willReturn(1);
 
 		SetupCommands setupCommands = new SetupCommands(tm, ComponentFlow.builder(), mockProcessUtil);
-		setupCommands.setup(new String[] { toInstall });
+		setupCommands.setup(new String[] { toInstall }, false);
 		assertThat(tm.getPrintAttributedMessages()).contains(String.format("Failed to install snap %s.", toInstall));
+	}
+
+	@Test
+	public void testAptUninstall() throws IOException {
+		String aptPackage = "openjdk-17-jdk";
+		String snapPackage = "docker";
+		String aptInstallPattern = "dpkg -s " + aptPackage;
+
+		// Report only openjdk-17-jdk as installed
+		given(mockProcessUtil.runProcess(any(), anyBoolean(), any(), any(), contains(aptInstallPattern))).willReturn(0);
+		given(mockProcessUtil.runProcess(any(), anyBoolean(), any(), any(), not(contains(aptInstallPattern))))
+			.willReturn(1);
+
+		// Expect the remove calls to succeed
+		given(mockProcessUtil.runProcess(any(), anyBoolean(), eq("sudo"), eq("apt-get"), eq("remove"), eq("-y"),
+				eq(aptPackage)))
+			.willReturn(0);
+
+		var setupCommands = new SetupCommands(new StubTerminalMessage(), ComponentFlow.builder(), mockProcessUtil);
+
+		setupCommands.setup(new String[] {}, true);
+
+		verify(mockProcessUtil).runProcess(any(), anyBoolean(), eq("sudo"), eq("apt-get"), eq("remove"), eq("-y"),
+				eq(aptPackage));
+		// we do not uninstall anything else, e.g. docker
+		verify(mockProcessUtil, never()).runProcess(any(), anyBoolean(), eq("sudo"), eq("snap"), eq("remove"),
+				eq(snapPackage));
+	}
+
+	@Test
+	public void testSnapUninstall() throws IOException {
+		String aptPackage = "openjdk-17-jdk";
+		String snapPackage = "docker";
+		String snapInstallPattern = "snap info " + snapPackage;
+
+		// Report only openjdk-17-jdk as installed
+		given(mockProcessUtil.runProcess(any(), anyBoolean(), any(), any(), contains(snapInstallPattern)))
+			.willReturn(0);
+		given(mockProcessUtil.runProcess(any(), anyBoolean(), any(), any(), not(contains(snapInstallPattern))))
+			.willReturn(1);
+
+		// Expect the remove calls to succeed
+		given(mockProcessUtil.runProcess(any(), anyBoolean(), eq("sudo"), eq("snap"), eq("remove"), eq(snapPackage)))
+			.willReturn(0);
+
+		var setupCommands = new SetupCommands(new StubTerminalMessage(), ComponentFlow.builder(), mockProcessUtil);
+
+		setupCommands.setup(new String[] {}, true);
+
+		verify(mockProcessUtil).runProcess(any(), anyBoolean(), eq("sudo"), eq("snap"), eq("remove"), eq(snapPackage));
+		// we do not uninstall anything else, e.g. apt packages
+		verify(mockProcessUtil, never()).runProcess(any(), anyBoolean(), eq("sudo"), eq("apt-get"), eq("remove"),
+				eq("-y"), eq(aptPackage));
+
+	}
+
+	@Test
+	public void testUninstallSkippedWhenNotInstalled() throws IOException {
+		// When uninstall=true but the package is not currently installed,
+		// remove() should return early without invoking any process.
+		String toRemove = "openjdk-17-jdk";
+
+		StubTerminalMessage tm = new StubTerminalMessage();
+		// Report the package as NOT installed
+		given(mockProcessUtil.runProcess(any(), anyBoolean(), any(), any(),
+				contains("grep -q \"Status: install ok installed\"")))
+			.willReturn(1);
+		given(mockProcessUtil.runProcess(any(), anyBoolean(), any(), any(), contains("| grep -q \"installed:\"")))
+			.willReturn(1);
+
+		SetupCommands setupCommands = new SetupCommands(tm, ComponentFlow.builder(), mockProcessUtil);
+		setupCommands.setup(new String[] {}, true);
+
+		// The apt-get remove command must never be issued
+		verify(mockProcessUtil, never()).runProcess(any(), anyBoolean(), eq("sudo"), eq("apt-get"), eq("remove"),
+				eq("-y"), eq(toRemove));
+		// The snap remove command must never be issued
+		verify(mockProcessUtil, never()).runProcess(any(), anyBoolean(), eq("sudo"), eq("snap"), eq("remove"),
+				eq(toRemove));
 	}
 
 }

--- a/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
+++ b/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
@@ -17,16 +17,21 @@
 package org.springframework.cli.command;
 
 import java.io.IOException;
+import java.util.List;
 
 import com.canonical.devpackspring.IProcessUtil;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.stubbing.Answer;
 
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.cli.support.MockConfigurations;
 import org.springframework.cli.util.StubTerminalMessage;
+import org.springframework.shell.component.context.ComponentContext;
 import org.springframework.shell.component.flow.ComponentFlow;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -212,6 +217,115 @@ public class SetupCommandsTests {
 		// The snap remove command must never be issued
 		verify(mockProcessUtil, never()).runProcess(any(), anyBoolean(), eq("sudo"), eq("snap"), eq("remove"),
 				eq(toRemove));
+	}
+
+	@Test
+	public void testWizardMultiSelectInstall() throws IOException {
+		String toInstall = "openjdk-17-jdk";
+		String description = "OpenJDK 17";
+
+		given(mockProcessUtil.runProcess(any(), anyBoolean(), any(), any(),
+				contains("grep -q \"Status: install ok installed\"")))
+			.willReturn(1);
+		given(mockProcessUtil.runProcess(any(), anyBoolean(), any(), any(), contains("| grep -q \"installed:\"")))
+			.willReturn(0);
+
+		ComponentContext<?> mockContext = Mockito.mock(ComponentContext.class);
+		Mockito.doReturn(List.of(toInstall)).when(mockContext).get("java");
+		setupMultiselect(mockContext);
+		// do not uninstall
+		Mockito.doReturn(Boolean.FALSE).when(mockContext).get("uninstall");
+
+		ComponentFlow.ComponentFlowResult mockResult = Mockito.mock(ComponentFlow.ComponentFlowResult.class);
+		Mockito.doReturn(mockContext).when(mockResult).getContext();
+
+		ComponentFlow mockFlow = Mockito.mock(ComponentFlow.class);
+		given(mockFlow.run()).willReturn(mockResult);
+
+		ComponentFlow.Builder mockBuilder = createMockBuilder(mockFlow);
+
+		StubTerminalMessage tm = new StubTerminalMessage();
+		SetupCommands setupCommands = new SetupCommands(tm, mockBuilder, mockProcessUtil);
+		setupCommands.setup(null, false);
+
+		assertThat(tm.getPrintMessages())
+			.contains(String.format("%s was successfully installed.", description));
+		// no package should have been removed
+		verify(mockProcessUtil, never()).runProcess(any(), anyBoolean(), eq("sudo"), eq("apt-get"),
+				eq("remove"), eq("-y"), any());
+		verify(mockProcessUtil, never()).runProcess(any(), anyBoolean(), eq("sudo"), eq("snap"),
+				eq("remove"), any());
+	}
+
+	@Test
+	public void testWizardConfirmationUninstall() throws IOException {
+		String aptPackage = "openjdk-17-jdk";
+		String aptCheckPattern = "dpkg -s " + aptPackage;
+		given(mockProcessUtil.runProcess(any(), anyBoolean(), any(), any(), contains(aptCheckPattern)))
+			.willReturn(0);
+		given(mockProcessUtil.runProcess(any(), anyBoolean(), any(), any(), not(contains(aptCheckPattern))))
+			.willReturn(1);
+		given(mockProcessUtil.runProcess(any(), anyBoolean(), eq("sudo"), eq("apt-get"), eq("remove"),
+				eq("-y"), eq(aptPackage)))
+			.willReturn(0);
+		ComponentContext<?> mockContext = Mockito.mock(ComponentContext.class);
+		Mockito.doReturn(List.of()).when(mockContext).get("java");
+		setupMultiselect(mockContext);
+
+		Mockito.doReturn(true).when(mockContext).get("uninstall"); // remove unselected
+
+		ComponentFlow.ComponentFlowResult mockResult = Mockito.mock(ComponentFlow.ComponentFlowResult.class);
+		Mockito.doReturn(mockContext).when(mockResult).getContext();
+
+		ComponentFlow mockFlow = Mockito.mock(ComponentFlow.class);
+		given(mockFlow.run()).willReturn(mockResult);
+
+		ComponentFlow.Builder mockBuilder = createMockBuilder(mockFlow);
+
+		var setupCommands = new SetupCommands(new StubTerminalMessage(), mockBuilder, mockProcessUtil);
+		// null add → wizard path
+		setupCommands.setup(null, false);
+
+		// openjdk-17-jdk was installed and not selected → must be removed
+		verify(mockProcessUtil).runProcess(any(), anyBoolean(), eq("sudo"), eq("apt-get"),
+				eq("remove"), eq("-y"), eq(aptPackage));
+	}
+
+	private static void setupMultiselect(ComponentContext<?> mockContext) {
+		Mockito.doReturn(List.of()).when(mockContext).get("docker");
+		Mockito.doReturn(List.of()).when(mockContext).get("ide");
+		Mockito.doReturn(List.of()).when(mockContext).get("misc");
+	}
+
+	private ComponentFlow.Builder createMockBuilder(ComponentFlow mockFlow) {
+		class BuilderHolder {
+			ComponentFlow.Builder builder;
+		}
+		final BuilderHolder holder = new BuilderHolder();
+		Answer<Object> builderAnswer = new Answer<Object>() {
+			@Override
+			public Object answer(InvocationOnMock invocation) throws Throwable {
+				Class<?> returnType = invocation.getMethod().getReturnType();
+				if (invocation.getMethod().getName().equals("toString")) {
+					return "MockBuilder";
+				}
+				if (returnType.isInstance(invocation.getMock())) {
+					return invocation.getMock();
+				}
+				if (returnType.isAssignableFrom(ComponentFlow.Builder.class)) {
+					return holder.builder;
+				}
+				if (returnType.isAssignableFrom(ComponentFlow.class)) {
+					return mockFlow;
+				}
+				if (returnType.isInterface() && returnType.getSimpleName().endsWith("Spec")) {
+					return Mockito.mock(returnType, this);
+				}
+				return Mockito.RETURNS_DEFAULTS.answer(invocation);
+			}
+		};
+		holder.builder = Mockito.mock(ComponentFlow.Builder.class, builderAnswer);
+		return holder.builder;
 	}
 
 }


### PR DESCRIPTION
This PR fixes inconsistency between UI wizard and `--add` command-line option. 
The wizard would uninstall unselected software, whereas --add option will just install selected software elements. 

The PR adds `--uninstall` option with the following semantics:
 - the wizard will prompt the user if he wants to uinstall unselected software. 
    - if the `--uninstall` option is present, the software will be removed automatically
 - when the list of installed software is passed through ` --add` command line option, `--uninstall` will remove software not selected via `--add` option.
