### PR TITLE
fix: fix parameter types

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.13.5
+version=0.13.6

--- a/src/main/java/org/springframework/cli/command/SetupCommands.java
+++ b/src/main/java/org/springframework/cli/command/SetupCommands.java
@@ -81,23 +81,24 @@ public class SetupCommands {
 
 	@Command(command = "setup", description = "Setup development environment")
 	public void setup(@Option(longNames = "add", description = "Software to install") String[] add,
-			@Option(longNames = "file", description = "Path to the software list file") Path configPath,
+			@Option(longNames = "file", description = "Path to the software list file") String configPath,
 			@Option(longNames = "save",
-					description = "Path to save the installed software list (defaults to $user.home/.config/devpack-for-spring/installed_config.yaml)") Path saveSetupList,
+					description = "Path to save the installed software list (defaults to $user.home/.config/devpack-for-spring/installed_config.yaml)") String saveSetupList,
 			@Option(description = "Uninstall unselected options", defaultValue = "false") boolean uninstall) {
 		try (InputStreamReader ir = new InputStreamReader(getSetupConfiguration())) {
 			SetupModel model = new SetupModel(ir, new SetupEntryFactory(processUtil));
 			if (add != null && configPath != null) {
 				throw new RuntimeException("Options --add and --file options are mutually exclusive.");
 			}
+			Path saveSetupPath = Path.of(saveSetupList);
 			if (add != null) {
 				headlessSetup(add, model, uninstall);
-				saveInstalledSoftware(saveSetupList, add);
+				saveInstalledSoftware(saveSetupPath, add);
 				return;
 			}
 
 			if (configPath != null) {
-				headlessSetup(loadSoftwareList(configPath), model, uninstall);
+				headlessSetup(loadSoftwareList(Path.of(configPath)), model, uninstall);
 				return;
 			}
 
@@ -150,7 +151,7 @@ public class SetupCommands {
 					}
 				}
 			}
-			saveInstalledSoftware(saveSetupList, installed.toArray(String[]::new));
+			saveInstalledSoftware(saveSetupPath, installed.toArray(String[]::new));
 		}
 		catch (IOException ex) {
 			throw new RuntimeException(ex);

--- a/src/main/java/org/springframework/cli/command/SetupCommands.java
+++ b/src/main/java/org/springframework/cli/command/SetupCommands.java
@@ -90,7 +90,7 @@ public class SetupCommands {
 			if (add != null && configPath != null) {
 				throw new RuntimeException("Options --add and --file options are mutually exclusive.");
 			}
-			Path saveSetupPath = Path.of(saveSetupList);
+			Path saveSetupPath = (saveSetupList != null) ? Path.of(saveSetupList) : null;
 			if (add != null) {
 				headlessSetup(add, model, uninstall);
 				saveInstalledSoftware(saveSetupPath, add);

--- a/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
+++ b/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
@@ -55,7 +55,7 @@ public class SetupCommandsTests {
 	@Mock
 	private IProcessUtil mockProcessUtil;
 
-	private Path tempPath;
+	private String tempPath;
 
 	private final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
 		.withUserConfiguration(MockConfigurations.MockBaseConfig.class);
@@ -64,7 +64,7 @@ public class SetupCommandsTests {
 	public void setUp() throws IOException {
 		var temp = File.createTempFile("install", "yaml");
 		temp.deleteOnExit();
-		tempPath = temp.toPath();
+		tempPath = temp.getAbsolutePath();
 	}
 
 	@Test
@@ -136,7 +136,7 @@ public class SetupCommandsTests {
 		SetupCommands setupCommands = new SetupCommands(tm, ComponentFlow.builder(), mockProcessUtil);
 		File installFile = File.createTempFile("install", ".tmp");
 		installFile.deleteOnExit();
-		setupCommands.setup(new String[] { toInstall }, null, installFile.toPath(), false);
+		setupCommands.setup(new String[] { toInstall }, null, installFile.getAbsolutePath(), false);
 		assertThat(tm.getPrintMessages()).contains(String.format("%s was successfully installed.", description));
 		assertThat(Files.readString(installFile.toPath())).isEqualTo("[docker]\n");
 	}
@@ -388,8 +388,7 @@ public class SetupCommandsTests {
 			StubTerminalMessage stub = new StubTerminalMessage();
 			SetupCommands setupCommands = new SetupCommands(stub, ComponentFlow.builder(), mockProcessUtil);
 			org.assertj.core.api.Assertions
-				.assertThatThrownBy(
-						() -> setupCommands.setup(new String[] { "foo" }, Path.of("config.yaml"), tempPath, false))
+				.assertThatThrownBy(() -> setupCommands.setup(new String[] { "foo" }, "config.yaml", tempPath, false))
 				.isInstanceOf(RuntimeException.class)
 				.hasMessage("Options --add and --file options are mutually exclusive.");
 		});
@@ -414,8 +413,8 @@ public class SetupCommandsTests {
 				assertThat(content).contains("openjdk-17-jdk").contains("openjdk-21-jdk");
 				File installFile = File.createTempFile("install", ".tmp");
 				installFile.deleteOnExit();
-				setupCommands.setup(new String[] { "openjdk-17-jdk", "openjdk-21-jdk" }, null, installFile.toPath(),
-						false);
+				setupCommands.setup(new String[] { "openjdk-17-jdk", "openjdk-21-jdk" }, null,
+						installFile.getAbsolutePath(), false);
 				assertThat(installFile).exists();
 
 			});
@@ -433,7 +432,7 @@ public class SetupCommandsTests {
 		this.contextRunner.withUserConfiguration(MockConfigurations.MockUserConfig.class).run((context) -> {
 			StubTerminalMessage stub = new StubTerminalMessage();
 			SetupCommands setupCommands = new SetupCommands(stub, ComponentFlow.builder(), mockProcessUtil);
-			assertThatThrownBy(() -> setupCommands.setup(null, configPath, tempPath, false))
+			assertThatThrownBy(() -> setupCommands.setup(null, configPath.toString(), tempPath, false))
 				.isInstanceOf(RuntimeException.class)
 				.hasCauseInstanceOf(IOException.class)
 				.hasMessageContaining("Missing software item definitions");


### PR DESCRIPTION
Spring shell command does not have converter for Path by default. 
Use String to pass the options for `setup` command.