### PR TITLE
feat: add retry option to setup command

### DIFF
--- a/src/main/java/com/canonical/devpackspring/CommandLineUtil.java
+++ b/src/main/java/com/canonical/devpackspring/CommandLineUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class CommandLineUtil {
+
+	private static final Pattern ARG_PATTERN = Pattern.compile("([^\"]\\S*|\"[^\"]*\")\\s*");
+
+	private CommandLineUtil() {
+	}
+
+	public static String[] splitArgs(String command) {
+		List<String> list = new ArrayList<>();
+		Matcher m = ARG_PATTERN.matcher(command.trim());
+		while (m.find()) {
+			list.add(m.group(1).replace("\"", "")); // Adds match and removes extra quotes
+		}
+		return list.toArray(new String[0]);
+	}
+
+}

--- a/src/main/java/com/canonical/devpackspring/CommandLineUtil.java
+++ b/src/main/java/com/canonical/devpackspring/CommandLineUtil.java
@@ -23,7 +23,7 @@ import java.util.regex.Pattern;
 
 public final class CommandLineUtil {
 
-	private static final Pattern ARG_PATTERN = Pattern.compile("([^\"]\\S*|\"[^\"]*\")\\s*");
+	private static final Pattern ARG_PATTERN = Pattern.compile("([^\"]\\S*|\"(?:[^\"\\\\]|\\\\.)*\")\\s*");
 
 	private CommandLineUtil() {
 	}
@@ -32,7 +32,12 @@ public final class CommandLineUtil {
 		List<String> list = new ArrayList<>();
 		Matcher m = ARG_PATTERN.matcher(command.trim());
 		while (m.find()) {
-			list.add(m.group(1).replace("\"", "")); // Adds match and removes extra quotes
+			String token = m.group(1);
+			if (token.startsWith("\"")) {
+				// Strip surrounding quotes then unescape \" → "
+				token = token.substring(1, token.length() - 1).replace("\\\"", "\"");
+			}
+			list.add(token);
 		}
 		return list.toArray(new String[0]);
 	}

--- a/src/main/java/com/canonical/devpackspring/setup/SetupEntry.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupEntry.java
@@ -18,10 +18,8 @@ package com.canonical.devpackspring.setup;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.List;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
+import com.canonical.devpackspring.CommandLineUtil;
 import com.canonical.devpackspring.IProcessUtil;
 import org.apache.commons.text.StringSubstitutor;
 
@@ -58,20 +56,11 @@ public abstract class SetupEntry extends DefaultSelectItem {
 		}
 		for (var command : extraCommands) {
 			command = StringSubstitutor.replaceSystemProperties(command); // expand macros
-			if (!runWithBackoff(retry, msg, ipc, splitArgs(command))) {
+			if (!runWithBackoff(retry, msg, ipc, CommandLineUtil.splitArgs(command))) {
 				return false;
 			}
 		}
 		return true;
-	}
-
-	private static String[] splitArgs(String command) {
-		List<String> list = new ArrayList<>();
-		Matcher m = Pattern.compile("([^\"]\\S*|\"[^\"]*\")\\s*").matcher(command);
-		while (m.find()) {
-			list.add(m.group(1).replace("\"", "")); // Adds match and removes extra quotes
-		}
-		return list.toArray(new String[0]);
 	}
 
 	protected boolean runWithBackoff(boolean retry, TerminalMessage msg, IProcessUtil ipc, String... args)
@@ -92,7 +81,7 @@ public abstract class SetupEntry extends DefaultSelectItem {
 		return true;
 	}
 
-	public static void backoff(int seconds) {
+	protected void backoff(int seconds) {
 		try {
 			Thread.sleep(seconds * 1000L);
 		}

--- a/src/main/java/com/canonical/devpackspring/setup/SetupEntry.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupEntry.java
@@ -55,12 +55,39 @@ public abstract class SetupEntry extends DefaultSelectItem {
 		}
 		for (var command : extraCommands) {
 			command = StringSubstitutor.replaceSystemProperties(command); // expand macros
-			int exitCode = ipc.runProcess(msg, true, command.split(" "));
-			if (exitCode != 0) {
+			if (!runWithBackoff(retry, msg, ipc, command.split(" "))) {
 				return false;
 			}
 		}
 		return true;
+	}
+
+	protected boolean runWithBackoff(boolean retry, TerminalMessage msg, IProcessUtil ipc, String... args)
+			throws IOException {
+		int backoff = 5;
+		while (ipc.runProcess(msg, true, args) != 0) {
+			if (!retry) {
+				return false;
+			}
+			msg.print(SetupStyles.error(
+					String.format("Command failed: %s. Retrying in %d seconds...", String.join(" ", args), backoff)));
+			backoff(backoff);
+			backoff *= 2;
+			if (backoff > 60) {
+				backoff = 60;
+			}
+		}
+		return true;
+	}
+
+	public static void backoff(int seconds) throws IOException {
+		try {
+			Thread.sleep(seconds * 1000L);
+		}
+		catch (InterruptedException e) {
+			throw new IOException("Interrupted while waiting to retry command", e);
+		}
+
 	}
 
 }

--- a/src/main/java/com/canonical/devpackspring/setup/SetupEntry.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupEntry.java
@@ -66,7 +66,6 @@ public abstract class SetupEntry extends DefaultSelectItem {
 	/**
 	 * Run the given command with an exponential backoff strategy until the command
 	 * succeeds.
-	 *
 	 * @param retry Whether to retry on failure
 	 * @param msg Terminal message to print errors to
 	 * @param ipc Process utility to run the command

--- a/src/main/java/com/canonical/devpackspring/setup/SetupEntry.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupEntry.java
@@ -18,6 +18,9 @@ package com.canonical.devpackspring.setup;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import com.canonical.devpackspring.IProcessUtil;
 import org.apache.commons.text.StringSubstitutor;
@@ -55,11 +58,20 @@ public abstract class SetupEntry extends DefaultSelectItem {
 		}
 		for (var command : extraCommands) {
 			command = StringSubstitutor.replaceSystemProperties(command); // expand macros
-			if (!runWithBackoff(retry, msg, ipc, command.split(" "))) {
+			if (!runWithBackoff(retry, msg, ipc, splitArgs(command))) {
 				return false;
 			}
 		}
 		return true;
+	}
+
+	private static String[] splitArgs(String command) {
+		List<String> list = new ArrayList<>();
+		Matcher m = Pattern.compile("([^\"]\\S*|\"[^\"]*\")\\s*").matcher(command);
+		while (m.find()) {
+			list.add(m.group(1).replace("\"", "")); // Adds match and removes extra quotes
+		}
+		return list.toArray(new String[0]);
 	}
 
 	protected boolean runWithBackoff(boolean retry, TerminalMessage msg, IProcessUtil ipc, String... args)
@@ -80,12 +92,12 @@ public abstract class SetupEntry extends DefaultSelectItem {
 		return true;
 	}
 
-	public static void backoff(int seconds) throws IOException {
+	public static void backoff(int seconds) {
 		try {
 			Thread.sleep(seconds * 1000L);
 		}
-		catch (InterruptedException e) {
-			throw new IOException("Interrupted while waiting to retry command", e);
+		catch (InterruptedException ex) {
+			throw new RuntimeException("Interrupted while waiting to retry command", ex);
 		}
 
 	}

--- a/src/main/java/com/canonical/devpackspring/setup/SetupEntry.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupEntry.java
@@ -63,6 +63,16 @@ public abstract class SetupEntry extends DefaultSelectItem {
 		return true;
 	}
 
+	/**
+	 * Run the given command with an exponential backoff strategy until the command
+	 * succeeds.
+	 *
+	 * @param retry Whether to retry on failure
+	 * @param msg Terminal message to print errors to
+	 * @param ipc Process utility to run the command
+	 * @param args Command to run
+	 * @return true if the command succeeded, false otherwise
+	 */
 	protected boolean runWithBackoff(boolean retry, TerminalMessage msg, IProcessUtil ipc, String... args)
 			throws IOException {
 		int backoff = 5;

--- a/src/main/java/com/canonical/devpackspring/setup/SetupEntryFactory.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupEntryFactory.java
@@ -98,6 +98,7 @@ public class SetupEntryFactory {
 					msg.print(SetupStyles.error(String.format("Failed to remove snap %s.", item())));
 					return false;
 				}
+				msg.print(SetupStyles.ok(String.format("%s was successfully removed.", name())));
 				return true;
 			}
 		};

--- a/src/main/java/com/canonical/devpackspring/setup/SetupEntryFactory.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupEntryFactory.java
@@ -21,8 +21,6 @@ import java.util.ArrayList;
 import java.util.Map;
 
 import com.canonical.devpackspring.IProcessUtil;
-import org.jline.utils.AttributedString;
-import org.jline.utils.AttributedStyle;
 
 import org.springframework.cli.util.TerminalMessage;
 
@@ -62,7 +60,6 @@ public class SetupEntryFactory {
 					msg.print(String.format("Snap %s is already installed.", item()));
 					return true;
 				}
-				AttributedStyle style = new AttributedStyle().foreground(AttributedStyle.RED);
 				ArrayList<String> call = new ArrayList<>();
 				call.add(SUDO);
 				call.add("snap");
@@ -74,18 +71,16 @@ public class SetupEntryFactory {
 				if (channel != null) {
 					call.add(String.format("--channel=%s", channel));
 				}
-				int exitCode = processUtil.runProcess(msg, true, call.toArray(String[]::new));
-				if (exitCode != 0) {
-					msg.print(new AttributedString(String.format("Failed to install snap %s.", item()), style));
+				if (!runWithBackoff(retry, msg, processUtil, call.toArray(String[]::new))) {
+					msg.print(SetupStyles.error(String.format("Failed to install snap %s.", item())));
 					return false;
 				}
 				boolean ret = executeExtraCommands(msg, retry, processUtil);
 				if (!ret) {
-					msg.print(new AttributedString(
-							String.format("Failed to install snap %s. Post-installation commands failed.", item()),
-							style));
+					msg.print(SetupStyles
+						.error(String.format("Failed to install snap %s. Post-installation commands failed.", item())));
 				}
-				msg.print(String.format("%s was successfully installed.", name()));
+				msg.print(SetupStyles.ok(String.format("%s was successfully installed.", name())));
 				return ret;
 			}
 
@@ -99,7 +94,11 @@ public class SetupEntryFactory {
 				if (!installed) {
 					return true;
 				}
-				return processUtil.runProcess(msg, true, SUDO, "snap", "remove", item()) == 0;
+				if (!runWithBackoff(retry, msg, processUtil, SUDO, "snap", "remove", item())) {
+					msg.print(SetupStyles.error(String.format("Failed to remove snap %s.", item())));
+					return false;
+				}
+				return true;
 			}
 		};
 	}
@@ -126,24 +125,21 @@ public class SetupEntryFactory {
 					msg.print(String.format("Package %s is already installed.", item()));
 					return true;
 				}
-				AttributedStyle style = new AttributedStyle().foreground(AttributedStyle.RED);
-				int exitCode = processUtil.runProcess(msg, true, SUDO, APT_GET, "update");
-				if (exitCode != 0) {
-					msg.print(new AttributedString(String.format("Failed to install package %s.", item()), style));
+
+				if (!runWithBackoff(retry, msg, processUtil, SUDO, APT_GET, "update")) {
+					msg.print(SetupStyles.error(String.format("Failed to install package %s.", item())));
 					return false;
 				}
-				exitCode = processUtil.runProcess(msg, true, SUDO, APT_GET, "install", "-y", item());
-				if (exitCode != 0) {
-					msg.print(new AttributedString(String.format("Failed to install package %s.", item()), style));
+				if (!runWithBackoff(retry, msg, processUtil, SUDO, APT_GET, "install", "-y", item())) {
+					msg.print(SetupStyles.error(String.format("Failed to install package %s.", item())));
 					return false;
 				}
 				boolean ret = executeExtraCommands(msg, retry, processUtil);
 				if (!ret) {
-					msg.print(new AttributedString(
-							String.format("Failed to install package %s. Post-installation commands failed.", item()),
-							style));
+					msg.print(SetupStyles.error(
+							String.format("Failed to install package %s. Post-installation commands failed.", item())));
 				}
-				msg.print(String.format("%s was successfully installed.", name()));
+				msg.print(SetupStyles.ok(String.format("%s was successfully installed.", name())));
 				return ret;
 			}
 
@@ -157,7 +153,12 @@ public class SetupEntryFactory {
 				if (!installed) {
 					return true;
 				}
-				return processUtil.runProcess(msg, true, SUDO, APT_GET, "remove", "-y", item()) == 0;
+				if (!runWithBackoff(retry, msg, processUtil, SUDO, APT_GET, "remove", "-y", item())) {
+					msg.print(SetupStyles.error(String.format("Failed to remove package %s.", item())));
+					return false;
+				}
+				msg.print(SetupStyles.ok(String.format("%s was successfully removed.", name())));
+				return true;
 			}
 		};
 	}

--- a/src/main/java/com/canonical/devpackspring/setup/SetupStyles.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupStyles.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring.setup;
+
+import org.jline.utils.AttributedStyle;
+import org.jline.utils.AttributedString;
+
+public class SetupStyles {
+
+	private static final AttributedStyle STYLE_ERROR = new AttributedStyle().foreground(AttributedStyle.RED);
+
+	private static final AttributedStyle STYLE_OK = new AttributedStyle().foreground(AttributedStyle.GREEN);
+
+	public static final AttributedString error(String message) {
+		return new AttributedString(message, STYLE_ERROR);
+	}
+
+	public static final AttributedString ok(String message) {
+		return new AttributedString(message, STYLE_OK);
+	}
+
+}

--- a/src/main/java/com/canonical/devpackspring/setup/SetupStyles.java
+++ b/src/main/java/com/canonical/devpackspring/setup/SetupStyles.java
@@ -16,20 +16,23 @@
 
 package com.canonical.devpackspring.setup;
 
-import org.jline.utils.AttributedStyle;
 import org.jline.utils.AttributedString;
+import org.jline.utils.AttributedStyle;
 
-public class SetupStyles {
+public final class SetupStyles {
 
 	private static final AttributedStyle STYLE_ERROR = new AttributedStyle().foreground(AttributedStyle.RED);
 
 	private static final AttributedStyle STYLE_OK = new AttributedStyle().foreground(AttributedStyle.GREEN);
 
-	public static final AttributedString error(String message) {
+	private SetupStyles() {
+	}
+
+	public static AttributedString error(String message) {
 		return new AttributedString(message, STYLE_ERROR);
 	}
 
-	public static final AttributedString ok(String message) {
+	public static AttributedString ok(String message) {
 		return new AttributedString(message, STYLE_OK);
 	}
 

--- a/src/test/java/com/canonical/devpackspring/CommandLineUtilTests.java
+++ b/src/test/java/com/canonical/devpackspring/CommandLineUtilTests.java
@@ -34,9 +34,9 @@ public class CommandLineUtilTests {
 
 	@Test
 	public void testSplitArgsQuotedExtraSpace() {
-		assertThat(CommandLineUtil.splitArgs("  foo   \"bar   baz\"   qux  ")).containsExactly("foo", "bar   baz", "qux");
+		assertThat(CommandLineUtil.splitArgs("  foo   \"bar   baz\"   qux  ")).containsExactly("foo", "bar   baz",
+				"qux");
 	}
-
 
 	@Test
 	public void testSplitArgsExtraWhitespace() {
@@ -46,6 +46,11 @@ public class CommandLineUtilTests {
 	@Test
 	public void testSplitArgsEmpty() {
 		assertThat(CommandLineUtil.splitArgs("")).isEmpty();
+	}
+
+	@Test
+	public void testSplitArgsEscapedQuote() {
+		assertThat(CommandLineUtil.splitArgs("foo \"bar\\\"baz\\\"\" qux")).containsExactly("foo", "bar\"baz\"", "qux");
 	}
 
 }

--- a/src/test/java/com/canonical/devpackspring/CommandLineUtilTests.java
+++ b/src/test/java/com/canonical/devpackspring/CommandLineUtilTests.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CommandLineUtilTests {
+
+	@Test
+	public void testSplitArgsSimple() {
+		assertThat(CommandLineUtil.splitArgs("foo bar baz")).containsExactly("foo", "bar", "baz");
+	}
+
+	@Test
+	public void testSplitArgsQuoted() {
+		assertThat(CommandLineUtil.splitArgs("foo \"bar baz\" qux")).containsExactly("foo", "bar baz", "qux");
+	}
+
+	@Test
+	public void testSplitArgsQuotedExtraSpace() {
+		assertThat(CommandLineUtil.splitArgs("  foo   \"bar   baz\"   qux  ")).containsExactly("foo", "bar   baz", "qux");
+	}
+
+
+	@Test
+	public void testSplitArgsExtraWhitespace() {
+		assertThat(CommandLineUtil.splitArgs("  foo   bar  ")).containsExactly("foo", "bar");
+	}
+
+	@Test
+	public void testSplitArgsEmpty() {
+		assertThat(CommandLineUtil.splitArgs("")).isEmpty();
+	}
+
+}

--- a/src/test/java/com/canonical/devpackspring/setup/SetupEntryTests.java
+++ b/src/test/java/com/canonical/devpackspring/setup/SetupEntryTests.java
@@ -85,7 +85,6 @@ public class SetupEntryTests {
 		assertThat(entry.backoffValues).isEqualTo(retryArray);
 	}
 
-
 	@Test
 	public void testExecuteExtraCommandsFailsOnError() throws IOException {
 		ArrayList<String> extras = new ArrayList<>(List.of("failing-cmd"));

--- a/src/test/java/com/canonical/devpackspring/setup/SetupEntryTests.java
+++ b/src/test/java/com/canonical/devpackspring/setup/SetupEntryTests.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.canonical.devpackspring.setup;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.canonical.devpackspring.IProcessUtil;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.cli.util.StubTerminalMessage;
+import org.springframework.cli.util.TerminalMessage;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+public class SetupEntryTests {
+
+	@Mock
+	private IProcessUtil mockProcessUtil;
+
+	@Test
+	public void testRetryFalse() throws IOException {
+		given(this.mockProcessUtil.runProcess(any(), anyBoolean(), any())).willReturn(1);
+
+		MockSetupEntry entry = new MockSetupEntry();
+		boolean result = entry.runWithBackoff(false, new StubTerminalMessage(), this.mockProcessUtil, "cmd");
+
+		assertThat(result).isFalse();
+		verify(this.mockProcessUtil, times(1)).runProcess(any(), anyBoolean(), any());
+	}
+
+	@Test
+	public void testRunSuccess() throws IOException {
+		given(this.mockProcessUtil.runProcess(any(), anyBoolean(), eq("sudo"), eq("apt-get"), eq("update")))
+			.willReturn(0);
+
+		MockSetupEntry entry = new MockSetupEntry();
+		boolean result = entry.runWithBackoff(true, new StubTerminalMessage(), this.mockProcessUtil, "sudo", "apt-get",
+				"update");
+
+		assertThat(result).isTrue();
+		verify(this.mockProcessUtil, times(1)).runProcess(any(), anyBoolean(), eq("sudo"), eq("apt-get"), eq("update"));
+		assertThat(entry.backoffValues).isEmpty();
+	}
+
+	@Test
+	public void testRetryProgression() throws IOException {
+		List<Integer> retryArray = List.of(5, 10, 20, 40, 60, 60);
+		AtomicInteger calls = new AtomicInteger(0);
+
+		given(this.mockProcessUtil.runProcess(any(), anyBoolean(), any())).willAnswer(_ -> (calls.incrementAndGet() < retryArray.size() +1) ? 1 : 0);
+
+		MockSetupEntry entry = new MockSetupEntry();
+		boolean result = entry.runWithBackoff(true, new StubTerminalMessage(), this.mockProcessUtil, "cmd");
+
+		assertThat(result).isTrue();
+		assertThat(calls.get()).isEqualTo( retryArray.size() +1);
+		assertThat(entry.backoffValues).isEqualTo(retryArray);
+	}
+
+
+	@Test
+	public void testExecuteExtraCommandsFailsOnError() throws IOException {
+		ArrayList<String> extras = new ArrayList<>(List.of("failing-cmd"));
+		MockSetupEntry entry = new MockSetupEntry(extras);
+		given(this.mockProcessUtil.runProcess(any(), anyBoolean(), eq("failing-cmd"))).willReturn(1);
+
+		boolean result = entry.executeExtraCommands(new StubTerminalMessage(), false, this.mockProcessUtil);
+
+		assertThat(result).isFalse();
+	}
+
+	private static class MockSetupEntry extends SetupEntry {
+
+		private final List<Integer> backoffValues = new ArrayList<>();
+
+		MockSetupEntry() {
+			super("test", "Test", null, true);
+		}
+
+		MockSetupEntry(ArrayList<String> extraCommands) {
+			super("test", "Test", extraCommands, true);
+		}
+
+		@Override
+		public boolean install(TerminalMessage msg, boolean retry, boolean dryRun) throws IOException {
+			return true;
+		}
+
+		@Override
+		public boolean remove(TerminalMessage msg, boolean retry, boolean dryRun) throws IOException {
+			return true;
+		}
+
+		@Override
+		protected void backoff(int seconds) {
+			this.backoffValues.add(seconds);
+		}
+
+	}
+
+}

--- a/src/test/java/com/canonical/devpackspring/setup/SetupEntryTests.java
+++ b/src/test/java/com/canonical/devpackspring/setup/SetupEntryTests.java
@@ -74,13 +74,14 @@ public class SetupEntryTests {
 		List<Integer> retryArray = List.of(5, 10, 20, 40, 60, 60);
 		AtomicInteger calls = new AtomicInteger(0);
 
-		given(this.mockProcessUtil.runProcess(any(), anyBoolean(), any())).willAnswer(_ -> (calls.incrementAndGet() < retryArray.size() +1) ? 1 : 0);
+		given(this.mockProcessUtil.runProcess(any(), anyBoolean(), any()))
+			.willAnswer(_ -> (calls.incrementAndGet() < retryArray.size() + 1) ? 1 : 0);
 
 		MockSetupEntry entry = new MockSetupEntry();
 		boolean result = entry.runWithBackoff(true, new StubTerminalMessage(), this.mockProcessUtil, "cmd");
 
 		assertThat(result).isTrue();
-		assertThat(calls.get()).isEqualTo( retryArray.size() +1);
+		assertThat(calls.get()).isEqualTo(retryArray.size() + 1);
 		assertThat(entry.backoffValues).isEqualTo(retryArray);
 	}
 

--- a/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
+++ b/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
@@ -145,6 +145,35 @@ public class SetupCommandsTests {
 	}
 
 	@Test
+	public void testRetrySnapInstall() throws IOException {
+		String toInstall = "docker";
+		String description = "docker - Docker container runtime snap";
+
+		StubTerminalMessage tm = new StubTerminalMessage();
+		// Report as NOT installed via dpkg (apt) and snap checks
+		given(mockProcessUtil.runProcess(any(), anyBoolean(), any(), any(),
+				contains("grep -q \"Status: install ok installed\"")))
+			.willReturn(0);
+		given(mockProcessUtil.runProcess(any(), anyBoolean(), any(), any(), contains("| grep -q \"installed:\"")))
+			.willReturn(1);
+
+		// First snap install attempt fails, second succeeds
+		given(mockProcessUtil.runProcess(any(), anyBoolean(), eq("sudo"), eq("snap"), eq("install"), eq(toInstall)))
+			.willReturn(1, 0);
+
+		SetupCommands setupCommands = new SetupCommands(tm, ComponentFlow.builder(), mockProcessUtil);
+		File installFile = File.createTempFile("install", ".tmp");
+		installFile.deleteOnExit();
+		setupCommands.setup(new String[] { toInstall }, null, installFile.getAbsolutePath(), false, false, true);
+
+		// The install command must have been called twice (initial attempt + one retry)
+		verify(mockProcessUtil, Mockito.times(2)).runProcess(any(), anyBoolean(), eq("sudo"), eq("snap"),
+				eq("install"), eq(toInstall));
+		assertThat(tm.getPrintAttributedMessages())
+			.contains(String.format("%s was successfully installed.", description));
+	}
+
+	@Test
 	public void testFailedSnapInstall() throws IOException {
 		String toInstall = "docker";
 

--- a/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
+++ b/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
@@ -96,7 +96,8 @@ public class SetupCommandsTests {
 			.willReturn(0);
 		SetupCommands setupCommands = new SetupCommands(tm, ComponentFlow.builder(), mockProcessUtil);
 		setupCommands.setup(new String[] { toInstall }, null, tempPath, false, false, false);
-		assertThat(tm.getPrintMessages()).contains(String.format("%s was successfully installed.", description));
+		assertThat(tm.getPrintAttributedMessages())
+			.contains(String.format("%s was successfully installed.", description));
 	}
 
 	@Test
@@ -138,7 +139,8 @@ public class SetupCommandsTests {
 		File installFile = File.createTempFile("install", ".tmp");
 		installFile.deleteOnExit();
 		setupCommands.setup(new String[] { toInstall }, null, installFile.getAbsolutePath(), false, false, false);
-		assertThat(tm.getPrintMessages()).contains(String.format("%s was successfully installed.", description));
+		assertThat(tm.getPrintAttributedMessages())
+			.contains(String.format("%s was successfully installed.", description));
 		assertThat(Files.readString(installFile.toPath())).isEqualTo("[docker]\n");
 	}
 
@@ -269,7 +271,8 @@ public class SetupCommandsTests {
 		SetupCommands setupCommands = new SetupCommands(tm, mockBuilder, mockProcessUtil);
 		setupCommands.setup(null, null, tempPath, false, false, false);
 
-		assertThat(tm.getPrintMessages()).contains(String.format("%s was successfully installed.", description));
+		assertThat(tm.getPrintAttributedMessages())
+			.contains(String.format("%s was successfully installed.", description));
 		// no package should have been removed
 		verify(mockProcessUtil, never()).runProcess(any(), anyBoolean(), eq("sudo"), eq("apt-get"), eq("remove"),
 				eq("-y"), any());

--- a/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
+++ b/src/test/java/org/springframework/cli/command/SetupCommandsTests.java
@@ -167,8 +167,8 @@ public class SetupCommandsTests {
 		setupCommands.setup(new String[] { toInstall }, null, installFile.getAbsolutePath(), false, false, true);
 
 		// The install command must have been called twice (initial attempt + one retry)
-		verify(mockProcessUtil, Mockito.times(2)).runProcess(any(), anyBoolean(), eq("sudo"), eq("snap"),
-				eq("install"), eq(toInstall));
+		verify(mockProcessUtil, Mockito.times(2)).runProcess(any(), anyBoolean(), eq("sudo"), eq("snap"), eq("install"),
+				eq(toInstall));
 		assertThat(tm.getPrintAttributedMessages())
 			.contains(String.format("%s was successfully installed.", description));
 	}


### PR DESCRIPTION
## Add retry logic with exponential backoff for setup commands

### Summary

This PR introduces automatic retry with exponential backoff for package and snap installation/removal commands. Previously, transient failures (e.g. network timeouts during `apt-get update` or `snap install`) would immediately abort the setup flow. With this change, commands are retried indefinitely with a capped backoff schedule when the `--retry` flag is set.

### Changes

**Retry infrastructure (`SetupEntry`)**
- Added `runWithBackoff(retry, msg, ipc, args...)` — a protected method that runs a command and, on failure, sleeps and retries using an exponential backoff starting at 5 seconds, doubling each attempt up to a maximum of 60 seconds. When `retry=false`, returns immediately on first failure.
- The `backoff()` method is `protected` and overridable, enabling tests to capture sleep values without blocking.

**Consistent styled output (`SetupStyles`)**
- Extracted a new `SetupStyles` utility class with static `error()` and `ok()` factory methods returning styled `AttributedString` instances (red and green respectively).
- Replaced all inline `new AttributedString(..., new AttributedStyle().foreground(...))` constructions in `SetupEntryFactory` with `SetupStyles` calls.
- Success messages for both install and remove operations are now styled in green for better UX.

**Correct argument splitting (`CommandLineUtil`)**
- Added `CommandLineUtil` with a `splitArgs()` method that correctly handles quoted arguments (including escaped quotes `\"` within strings).
- `executeExtraCommands` now uses `CommandLineUtil.splitArgs()` instead of `String.split(" ")`, fixing handling of extra commands with quoted or space-containing arguments.

### Tests

- `SetupEntryTests` — unit tests for `runWithBackoff`: verifies no-retry behaviour, immediate success path (no backoff), the full backoff progression `[5, 10, 20, 40, 60, 60]` seconds, and failure propagation in `executeExtraCommands`.
- `SetupCommandsTests` — added an end-to-end retry test: first `snap install` attempt fails, second succeeds; verifies the command was called twice and success message is printed.
- `CommandLineUtilTests` — covers simple args, quoted args with spaces, extra whitespace, empty input, and escaped quotes within quoted strings.

