### PR TITLE
feat: update menu structure

### DIFF
--- a/src/main/java/org/springframework/cli/command/BuildCommands.java
+++ b/src/main/java/org/springframework/cli/command/BuildCommands.java
@@ -37,6 +37,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cli.util.IoUtils;
 import org.springframework.cli.util.TerminalMessage;
 import org.springframework.shell.core.command.annotation.Command;
+import org.springframework.shell.core.command.annotation.CommandGroup;
 import org.springframework.shell.core.command.annotation.Option;
 import org.springframework.shell.jline.tui.component.flow.ComponentFlow;
 import org.springframework.shell.jline.tui.component.flow.DefaultSelectItem;
@@ -51,6 +52,7 @@ import org.springframework.shell.jline.tui.table.TableModel;
 import org.springframework.stereotype.Component;
 
 @Component
+@CommandGroup(prefix = "", name = "Plugins")
 public class BuildCommands {
 
 	public static final String PLUGIN_CONFIGURATION = "SPRING_CLI_BUILD_COMMANDS_PLUGIN_CONFIGURATION";
@@ -86,7 +88,7 @@ public class BuildCommands {
 		return ConfigUtil.openConfigurationFile(PLUGIN_CONFIGURATION, "plugin-configuration.yaml");
 	}
 
-	@Command(name = "plugin", description = "Run a build plugin for the project")
+	@Command(name = "run", description = "Run a build plugin for the project")
 	public void run(@Option(description = "plugin name") String plugin,
 			@Option(description = "task/goal") String command, @Option(description = "project path") Path projectPath)
 			throws IOException {
@@ -187,7 +189,7 @@ public class BuildCommands {
 		}
 	}
 
-	@Command(name = "plugin-init", description = "Initialize local plugin configuration in .devpack-for-spring/plugin-configuration.yaml")
+	@Command(name = "init-plugin", description = "Initialize local plugin configuration in .devpack-for-spring/plugin-configuration.yaml")
 	public void initPluginConfiguration(@Option(description = "project path") Path projectPath) throws IOException {
 		if (projectPath == null) {
 			projectPath = workingDir;
@@ -210,7 +212,7 @@ public class BuildCommands {
 		terminalMessage.print("Created " + target);
 	}
 
-	@Command(name = "list-plugins", description = "List supported build plugins")
+	@Command(name = "plugins", description = "List supported build plugins")
 	public Table list() {
 		// TODO: check build system and print applicable plugins
 		var header = Stream.<String[]>of(new String[] { "Name", "Id", "Description", "Build System" });

--- a/src/main/java/org/springframework/cli/command/SetupCommands.java
+++ b/src/main/java/org/springframework/cli/command/SetupCommands.java
@@ -39,6 +39,7 @@ import org.yaml.snakeyaml.Yaml;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cli.util.TerminalMessage;
 import org.springframework.shell.core.command.annotation.Command;
+import org.springframework.shell.core.command.annotation.CommandGroup;
 import org.springframework.shell.core.command.annotation.Option;
 import org.springframework.shell.jline.tui.component.flow.ComponentFlow;
 import org.springframework.shell.jline.tui.component.flow.ResultMode;
@@ -47,6 +48,7 @@ import org.springframework.shell.jline.tui.component.support.Nameable;
 import org.springframework.stereotype.Component;
 
 @Component
+@CommandGroup(prefix = "", name = "Devpack")
 public class SetupCommands {
 
 	public static final String SETUP_CONFIGURATION = "SPRING_CLI_SETUP_COMMANDS_CONFIGURATION";

--- a/src/main/java/org/springframework/cli/command/SnapCommands.java
+++ b/src/main/java/org/springframework/cli/command/SnapCommands.java
@@ -49,7 +49,7 @@ import org.springframework.stereotype.Component;
  * This command is responsible for the manipulation of the content snaps
  */
 @Component
-@CommandGroup(prefix = "snap", name = "Devpack")
+@CommandGroup(prefix = "", name = "Devpack")
 public class SnapCommands {
 
 	private static final String SNAP_PARAMETER_ID = "snap";
@@ -67,7 +67,7 @@ public class SnapCommands {
 		this.terminalMessage = terminalMessage;
 	}
 
-	@Command(name = "list", description = "List available libraries packaged as a snap.")
+	@Command(name = "libraries", description = "List available libraries packaged as a snap.")
 	public Table list() {
 		try {
 			var header = Stream.<String[]>of(new String[] { "Installed", "Name", "Channel", "Version", "Description" });
@@ -87,7 +87,7 @@ public class SnapCommands {
 		}
 	}
 
-	@Command(name = "install", description = "Install a snap-packaged library.")
+	@Command(name = "add-library", description = "Install a snap-packaged library.")
 	public String install(@Option(description = "Name of the library to install") String snap)
 			throws IOException, InterruptedException, XPathExpressionException, ParserConfigurationException,
 			TransformerException, SAXException {
@@ -114,7 +114,7 @@ public class SnapCommands {
 		return String.format("Installed %s.", toInstall.name());
 	}
 
-	@Command(name = "setup-gradle", description = "Setup Gradle to use snap-packaged libraries.")
+	@Command(name = "gradle-libraries", description = "Setup Gradle to use snap-packaged libraries.")
 	public void setupGradle() throws IOException {
 		var manifest = new Manifest();
 		var snaps = manifest.load(loadManifest());
@@ -128,7 +128,7 @@ public class SnapCommands {
 		});
 	}
 
-	@Command(name = "setup-maven", description = "Setup Maven to use snap-packaged libraries.")
+	@Command(name = "maven-libraries", description = "Setup Maven to use snap-packaged libraries.")
 	public void setupMaven() throws IOException {
 		var manifest = new Manifest();
 		var snaps = manifest.load(loadManifest());
@@ -142,7 +142,7 @@ public class SnapCommands {
 		});
 	}
 
-	@Command(name = "remove", description = "Remove a snap-packaged library.")
+	@Command(name = "remove-library", description = "Remove a snap-packaged library.")
 	public String remove(@Option(description = "Name of the library to remove") String snap)
 			throws IOException, InterruptedException {
 		Snap toRemove = getSnap(snap, true);

--- a/src/main/resources/devpack-for-springcliapp.yml
+++ b/src/main/resources/devpack-for-springcliapp.yml
@@ -13,6 +13,12 @@ spring:
         root-command: devpack-for-spring
       version:
         show-git-short-commit-id: true
+      clear:
+        enabled: false
+      history:
+        enabled: false
+      script:
+        enabled: false
 devpack-for-spring:
     cli:
 


### PR DESCRIPTION
This PR updates menu structure of devpack-for-spring commands to 
```
AVAILABLE COMMANDS

Boot
        boot start: Create a new project from start.spring.io
Built-In Commands
        help: Show help about available commands
        quit, exit: Exit the shell
        version: Show version info
Devpack
        add-library: Install a snap-packaged library.
        gradle-libraries: Setup Gradle to use snap-packaged libraries.
        libraries: List available libraries packaged as a snap.
        maven-libraries: Setup Maven to use snap-packaged libraries.
        remove-library: Remove a snap-packaged library.
        setup: Setup development environment
Plugins
        init-plugin: Initialize local plugin configuration in .devpack-for-spring/plugin-configuration.yaml
        plugins: List supported build plugins
        run: Run a build plugin for the project
```

Note: quit is hardcoded by Spring Shell. I will try to remove the hardcode upstream.