### PR TITLE
fix: use '=' in gradle init file template.

### DIFF
--- a/src/main/java/com/canonical/devpackspring/snap/GradleInit.java
+++ b/src/main/java/com/canonical/devpackspring/snap/GradleInit.java
@@ -37,8 +37,8 @@ public class GradleInit {
 					gradle.beforeSettings { settings ->
 						settings.pluginManagement.repositories { handler ->
 							var repo = maven {
-									name "plugin-%s"
-									url "file:///snap/%s/current/maven-repo/"
+									name="plugin-%s"
+									url="file:///snap/%s/current/maven-repo/"
 								}
 							handler.remove(repo)
 							handler.addFirst(repo)
@@ -47,8 +47,8 @@ public class GradleInit {
 					gradle.allprojects { project ->
 						project.repositories {
 							maven {
-								name "%s"
-								url "file:///snap/%s/current/maven-repo/"
+								name="%s"
+								url="file:///snap/%s/current/maven-repo/"
 							}
 						}
 					}

--- a/src/test/java/com/canonical/devpackspring/snap/GradleInitTests.java
+++ b/src/test/java/com/canonical/devpackspring/snap/GradleInitTests.java
@@ -37,8 +37,8 @@ public class GradleInitTests {
 		var init = new GradleInit(outputDir);
 		init.addGradleInitFile(snap);
 		String result = Files.readString(Path.of(outputDir.getAbsolutePath(), "foo.gradle"));
-		assertThat(result).contains("url \"file:///snap/foo/current/maven-repo/\"");
-		assertThat(result).contains("name \"foo\"");
+		assertThat(result).contains("url=\"file:///snap/foo/current/maven-repo/\"");
+		assertThat(result).contains("name=\"foo\"");
 	}
 
 }


### PR DESCRIPTION
This PR Fixes: https://github.com/canonical/devpack-for-spring/issues/180

The gradle.init should use = when assigning values. 