### PR TITLE
feat: use system proxy settings for http client

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-version=0.14.2
+version=0.14.3

--- a/src/main/java/org/springframework/cli/config/ProxyConfiguration.java
+++ b/src/main/java/org/springframework/cli/config/ProxyConfiguration.java
@@ -1,0 +1,208 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cli.config;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ProxyConfiguration {
+
+	private static final Logger logger = LoggerFactory.getLogger(ProxyConfiguration.class);
+
+	private final boolean debug;
+
+	public ProxyConfiguration(@Value("${app.debug:false}") boolean debug) {
+		this.debug = debug;
+	}
+
+	@PostConstruct
+	public void configure() {
+		setProxySystemProperties(System.getenv());
+	}
+
+	public void setProxySystemProperties(Map<String, String> env) {
+		Map<String, String> proxyEnv = new HashMap<>();
+		for (var proxyVar : new String[] { "http_proxy", "https_proxy", "no_proxy" }) {
+			var value = env.get(proxyVar);
+			if (value == null) {
+				value = env.get(proxyVar.toUpperCase());
+			}
+			if (value != null) {
+				proxyEnv.put(proxyVar, value);
+			}
+		}
+		for (var key : proxyEnv.keySet()) {
+			var value = proxyEnv.get(key);
+			switch (key) {
+				case "no_proxy" -> setNoProxy(value);
+				case "http_proxy" ->
+					setProxy(key, value, "http.proxyHost", "http.proxyPort", "http.proxyUser", "http.proxyPassword");
+				case "https_proxy" -> setProxy(key, value, "https.proxyHost", "https.proxyPort", "https.proxyUser",
+						"https.proxyPassword");
+			}
+		}
+	}
+
+	private void setNoProxy(String value) {
+		var noProxy = toNonProxyHosts(value);
+		if (noProxy != null) {
+			System.setProperty("http.nonProxyHosts", noProxy);
+		}
+		else {
+			System.clearProperty("http.nonProxyHosts");
+		}
+	}
+
+	private String toNonProxyHosts(String noProxy) {
+		if (noProxy == null || noProxy.isBlank()) {
+			return null;
+		}
+		var hosts = new java.util.ArrayList<String>();
+		for (var raw : noProxy.split(",")) {
+			var entry = raw.trim();
+			if (entry.isEmpty()) {
+				continue;
+			}
+			// Bare '*' means "bypass everything" — not expressible in nonProxyHosts.
+			if (entry.equals("*")) {
+				logger.warn("Skipped wildcard entry - please unset proxy settings to bypass proxy");
+				continue;
+			}
+			// Skip CIDR ranges (e.g. 10.0.0.0/8); http.nonProxyHosts has no CIDR support.
+			if (entry.contains("/")) {
+				logger.warn("Skipped {} entry - URLs and CIDR entries are not supported", entry);
+				continue;
+			}
+			// A leading dot is the no_proxy wildcard-suffix form (".example.com").
+			// Normalize to the JVM form "*.example.com".
+			if (entry.startsWith(".")) {
+				entry = "*" + entry;
+			}
+			// Leading "*." is already valid for http.nonProxyHosts.
+			hosts.add(entry);
+		}
+		return hosts.isEmpty() ? null : String.join("|", hosts);
+	}
+
+	private void setProxy(String key, String value, String hostProperty, String portProperty, String userProperty,
+			String passwordProperty) {
+		try {
+			value = amendScheme(key, value);
+			URI uri = new URI(value);
+			var host = uri.getHost();
+			if (host == null) {
+				setAuthorityProxy(key, uri.getAuthority(), hostProperty, portProperty, userProperty, passwordProperty);
+				return;
+			}
+			System.setProperty(hostProperty, host);
+
+			int port = uri.getPort();
+			if (port == -1) {
+				port = "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
+			}
+
+			System.setProperty(portProperty, String.valueOf(port));
+
+			String info = uri.getUserInfo();
+			if (info != null) {
+				var userPass = info.split(":", 2);
+				System.setProperty(userProperty, userPass[0]);
+				if (userPass.length > 1) {
+					System.setProperty(passwordProperty, userPass[1]);
+				}
+			}
+		}
+		catch (URISyntaxException ex) {
+			// do not leak userInfo in the console messages, those
+			// can be logged in CI
+			var idx = value.lastIndexOf('@');
+			var sanitisedURI = (idx >= 0) ? value.substring(idx + 1) : value;
+			var exceptionMessage = ex.getMessage().replace(value, sanitisedURI);
+			String message = key + "=" + sanitisedURI + " - " + exceptionMessage;
+			logger.error(message);
+			if (debug) {
+				throw new RuntimeException(message);
+			}
+		}
+	}
+
+	private String amendScheme(String key, String value) {
+		if (!value.contains("://")) {
+			if ("http_proxy".equals(key)) {
+				return "http://" + value;
+			}
+			if ("https_proxy".equals(key)) {
+				return "https://" + value;
+			}
+		}
+		return value;
+	}
+
+	private void setAuthorityProxy(String key, String authority, String hostProperty, String portProperty,
+			String userProperty, String passwordProperty) {
+		if (authority == null) {
+			logger.warn("Unable to set {} because the host is empty", key);
+			return;
+		}
+		var userPass = authority.split("@", 2);
+		String hostPort = (userPass.length > 1) ? userPass[1] : userPass[0];
+		if (userPass.length > 1) {
+			var credentials = userPass[0].split(":", 2);
+			System.setProperty(userProperty, credentials[0]);
+			if (credentials.length > 1) {
+				System.setProperty(passwordProperty, credentials[1]);
+			}
+		}
+
+		int portPos = hostPort.lastIndexOf(":");
+		if (portPos == -1) {
+			portPos = hostPort.length();
+		}
+		String host = hostPort.substring(0, portPos);
+		if (host.isEmpty()) {
+			logger.warn("Unable to set {} because the host is empty", key);
+			return;
+		}
+		System.setProperty(hostProperty, host);
+
+		int port;
+		if (portPos < hostPort.length()) {
+			try {
+				port = Integer.parseInt(hostPort.substring(portPos + 1, hostPort.length()));
+			}
+			catch (NumberFormatException ex) {
+				logger.warn("{} - unable to parse the port value, {}", key, ex.getMessage());
+				return;
+			}
+		}
+		else {
+			port = "https_proxy".equals(key) ? 443 : 80;
+		}
+		System.setProperty(portProperty, String.valueOf(port));
+	}
+
+}

--- a/src/main/java/org/springframework/cli/config/SpringCliConfiguration.java
+++ b/src/main/java/org/springframework/cli/config/SpringCliConfiguration.java
@@ -19,6 +19,7 @@ package org.springframework.cli.config;
 import java.time.Duration;
 
 import org.jline.terminal.Terminal;
+import reactor.netty.transport.ClientTransport;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -28,6 +29,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 import org.springframework.http.client.ReactorResourceFactory;
+import org.springframework.http.client.reactive.ReactorClientHttpConnector;
 import org.springframework.shell.core.ShellRunner;
 import org.springframework.shell.core.command.CommandParser;
 import org.springframework.shell.core.command.CommandRegistry;
@@ -45,12 +47,14 @@ import org.springframework.web.reactive.function.client.WebClient;
 public class SpringCliConfiguration {
 
 	/**
-	 * Workaround Intellij IDEA debugger issue
+	 * @param factory - resource factory
+	 * @param config - inject ProxyConfiguration to ensure it is run before this method
 	 * @return WebClient.Builder
 	 */
 	@Bean
-	public WebClient.Builder webClientBuilder() {
-		return WebClient.builder();
+	public WebClient.Builder webClientBuilder(ReactorResourceFactory factory, ProxyConfiguration config) {
+		return WebClient.builder()
+			.clientConnector(new ReactorClientHttpConnector(factory, ClientTransport::proxyWithSystemProperties));
 	}
 
 	@Bean

--- a/src/test/java/org/springframework/cli/config/ProxyConfigurationTests.java
+++ b/src/test/java/org/springframework/cli/config/ProxyConfigurationTests.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright 2026 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.cli.config;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class ProxyConfigurationTests {
+
+	private static final String[] PROXY_PROPERTIES = { "http.proxyHost", "http.proxyPort", "https.proxyHost",
+			"https.proxyPort", "http.nonProxyHosts", "http.proxyUser", "http.proxyPassword", "https.proxyUser",
+			"https.proxyPassword", };
+
+	private final ProxyConfiguration configuration = new ProxyConfiguration(true);
+
+	private final Map<String, String> originalProperties = new HashMap<>();
+
+	@BeforeEach
+	void saveSystemProperties() {
+		for (String key : PROXY_PROPERTIES) {
+			this.originalProperties.put(key, System.getProperty(key));
+		}
+	}
+
+	@AfterEach
+	void restoreSystemProperties() {
+		for (Map.Entry<String, String> entry : this.originalProperties.entrySet()) {
+			if (entry.getValue() == null) {
+				System.clearProperty(entry.getKey());
+			}
+			else {
+				System.setProperty(entry.getKey(), entry.getValue());
+			}
+		}
+		this.originalProperties.clear();
+	}
+
+	@Test
+	public void httpProxyWithAuth() {
+		this.configuration.setProxySystemProperties(Map.of("http_proxy", "http://user@host/"));
+		Assertions.assertThat(System.getProperty("http.proxyUser")).isEqualTo("user");
+	}
+
+	@Test
+	public void httpProxyWithAuthPass() {
+		this.configuration.setProxySystemProperties(Map.of("http_proxy", "http://user:pass@host/"));
+		Assertions.assertThat(System.getProperty("http.proxyUser")).isEqualTo("user");
+		Assertions.assertThat(System.getProperty("http.proxyPassword")).isEqualTo("pass");
+	}
+
+	@Test
+	public void httpProxyWithUnderscore() {
+		this.configuration.setProxySystemProperties(Map.of("http_proxy", "http://my_proxy/"));
+		Assertions.assertThat(System.getProperty("http.proxyHost")).isEqualTo("my_proxy");
+	}
+
+	@Test
+	public void assumeSchemaHttp() {
+		this.configuration.setProxySystemProperties(Map.of("http_proxy", "my_proxy"));
+		Assertions.assertThat(System.getProperty("http.proxyHost")).isEqualTo("my_proxy");
+	}
+
+	@Test
+	public void assumeSchemaHttps() {
+		this.configuration.setProxySystemProperties(Map.of("https_proxy", "my_proxy"));
+		Assertions.assertThat(System.getProperty("https.proxyHost")).isEqualTo("my_proxy");
+	}
+
+	@Test
+	public void httpProxyWithUnderscorePort() {
+		this.configuration.setProxySystemProperties(Map.of("http_proxy", "http://my_proxy:90/"));
+		Assertions.assertThat(System.getProperty("http.proxyHost")).isEqualTo("my_proxy");
+		Assertions.assertThat(System.getProperty("http.proxyPort")).isEqualTo("90");
+	}
+
+	@Test
+	public void httpsProxyWithAuthPass() {
+		this.configuration.setProxySystemProperties(Map.of("https_proxy", "https://user:pa:ss@host/"));
+		Assertions.assertThat(System.getProperty("https.proxyHost")).isEqualTo("host");
+		Assertions.assertThat(System.getProperty("https.proxyPort")).isEqualTo("443");
+		Assertions.assertThat(System.getProperty("https.proxyUser")).isEqualTo("user");
+		Assertions.assertThat(System.getProperty("https.proxyPassword")).isEqualTo("pa:ss");
+	}
+
+	@Test
+	public void httpProxyWithoutPortDefaultsTo80() {
+		this.configuration.setProxySystemProperties(Map.of("http_proxy", "http://host/"));
+		Assertions.assertThat(System.getProperty("http.proxyHost")).isEqualTo("host");
+		Assertions.assertThat(System.getProperty("http.proxyPort")).isEqualTo("80");
+	}
+
+	@Test
+	public void httpProxyWithPortUsesProvidedPort() {
+		this.configuration.setProxySystemProperties(Map.of("http_proxy", "http://host:8080"));
+		Assertions.assertThat(System.getProperty("http.proxyHost")).isEqualTo("host");
+		Assertions.assertThat(System.getProperty("http.proxyPort")).isEqualTo("8080");
+	}
+
+	@Test
+	public void httpsProxyWithoutPortDefaultsTo443() {
+		this.configuration.setProxySystemProperties(Map.of("https_proxy", "https://host/"));
+		Assertions.assertThat(System.getProperty("https.proxyHost")).isEqualTo("host");
+		Assertions.assertThat(System.getProperty("https.proxyPort")).isEqualTo("443");
+	}
+
+	@Test
+	public void noProxySetsHttpNonProxyHosts() {
+		this.configuration.setProxySystemProperties(Map.of("no_proxy", "localhost,example.com"));
+		Assertions.assertThat(System.getProperty("http.nonProxyHosts")).isEqualTo("localhost|example.com");
+	}
+
+	@Test
+	public void noProxySkipsSlash() {
+		this.configuration.setProxySystemProperties(Map.of("no_proxy", "localhost/80,example.com"));
+		Assertions.assertThat(System.getProperty("http.nonProxyHosts")).isEqualTo("example.com");
+	}
+
+	@Test
+	public void noProxyClearsProperty() {
+		this.configuration.setProxySystemProperties(Map.of("no_proxy", "*"));
+		Assertions.assertThat(System.getProperty("http.nonProxyHosts")).isNull();
+	}
+
+	@Test
+	public void noProxySkipsWildcard() {
+		this.configuration.setProxySystemProperties(Map.of("no_proxy", "*,example.com"));
+		Assertions.assertThat(System.getProperty("http.nonProxyHosts")).isEqualTo("example.com");
+	}
+
+	@Test
+	public void noProxyAmendsDot() {
+		this.configuration.setProxySystemProperties(Map.of("no_proxy", ".example.com"));
+		Assertions.assertThat(System.getProperty("http.nonProxyHosts")).isEqualTo("*.example.com");
+	}
+
+	@Test
+	public void upperCaseProxyVariablesAreUsed() {
+		this.configuration.setProxySystemProperties(Map.of("HTTP_PROXY", "http://host/"));
+		Assertions.assertThat(System.getProperty("http.proxyHost")).isEqualTo("host");
+		Assertions.assertThat(System.getProperty("http.proxyPort")).isEqualTo("80");
+	}
+
+	@Test
+	public void nullHostUrl() {
+		Assertions
+			.assertThatThrownBy(() -> this.configuration.setProxySystemProperties(Map.of("HTTP_PROXY", "http://")))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessageContaining("http_proxy=http:// -");
+	}
+
+	@Test
+	public void malformedHttpProxyThrowsRuntimeException() {
+		Assertions
+			.assertThatThrownBy(() -> this.configuration.setProxySystemProperties(Map.of("http_proxy", "not a url")))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessageContaining("http_proxy=http://not a url -");
+	}
+
+	@Test
+	public void malformedHttpProxyNoUserInfo() {
+		Assertions
+			.assertThatThrownBy(
+					() -> this.configuration.setProxySystemProperties(Map.of("http_proxy", "http://foo:bar@not a url")))
+			.isInstanceOf(RuntimeException.class)
+			.hasMessageContaining("http_proxy=not a url -")
+			.extracting(Throwable::getMessage, Assertions.as(Assertions.STRING))
+			.doesNotContain("foo:bar");
+	}
+
+}


### PR DESCRIPTION
devpack for spring `boot start` command does not honour system proxy settings. 
Add class to initialize JVM proxy properties from the system environment.

Fixes: https://github.com/canonical/devpack-for-spring/issues/208